### PR TITLE
Add page numbering to Automation Architect HTML guide

### DIFF
--- a/automation_architect.html
+++ b/automation_architect.html
@@ -1,0 +1,1842 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>The Automation Architect: Building the Self-Scaling Enterprise</title>
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;800&family=Fira+Code:wght@300;400;500;600;700&display=swap');
+:root {
+  --background: #0a0a1a;
+  --text: #d0e0ff;
+  --primary: #ff00ff;
+  --secondary: #00ffff;
+  --accent: #39ff14;
+  --code: #ffff00;
+  --card-bg: rgba(10, 20, 40, 0.85);
+  --border: rgba(0, 255, 255, 0.4);
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--background);
+  background-image: radial-gradient(circle at 10% 20%, rgba(255, 0, 255, 0.08) 0%, transparent 35%),
+                    radial-gradient(circle at 90% 10%, rgba(57, 255, 20, 0.06) 0%, transparent 45%),
+                    linear-gradient(135deg, rgba(0, 255, 255, 0.04) 0%, transparent 60%),
+                    linear-gradient(45deg, rgba(255, 255, 0, 0.02) 0%, transparent 70%);
+  color: var(--text);
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  line-height: 1.6;
+  counter-reset: page;
+}
+main {
+  width: min(960px, 90vw);
+  margin: 0 auto;
+  padding: 2rem 0 4rem 0;
+}
+header, footer {
+  width: min(960px, 90vw);
+  margin: 0 auto;
+  padding: 3rem 0;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Orbitron', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+h1 {
+  color: var(--primary);
+  font-size: clamp(2.5rem, 5vw, 3.4rem);
+  text-shadow: 0 0 15px rgba(255, 0, 255, 0.6);
+}
+h2 {
+  color: var(--primary);
+  font-size: clamp(1.8rem, 4vw, 2.5rem);
+  margin-top: 0.5rem;
+  text-shadow: 0 0 12px rgba(255, 0, 255, 0.5);
+}
+h3, h4 {
+  color: var(--secondary);
+  text-shadow: 0 0 8px rgba(0, 255, 255, 0.5);
+}
+a {
+  color: var(--accent);
+  text-decoration: none;
+  transition: color 0.3s ease, text-shadow 0.3s ease;
+}
+a:hover {
+  color: var(--primary);
+  text-shadow: 0 0 6px rgba(57, 255, 20, 0.6);
+}
+p {
+  margin-bottom: 1.2rem;
+}
+strong, em {
+  color: var(--accent);
+}
+code {
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  color: var(--code);
+  background: rgba(255, 255, 0, 0.12);
+  padding: 0.2rem 0.35rem;
+  border-radius: 4px;
+}
+pre {
+  background: rgba(10, 10, 40, 0.95);
+  border: 1px solid rgba(255, 0, 255, 0.25);
+  border-radius: 10px;
+  padding: 1.5rem;
+  overflow-x: auto;
+  box-shadow: 0 0 20px rgba(255, 0, 255, 0.15);
+  margin-bottom: 2rem;
+}
+pre code {
+  background: transparent;
+  color: #ffe066;
+  font-size: 0.95rem;
+}
+ul, ol {
+  padding-left: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+li {
+  margin-bottom: 0.7rem;
+}
+blockquote {
+  border-left: 4px solid var(--secondary);
+  padding-left: 1.5rem;
+  color: rgba(208, 224, 255, 0.85);
+  font-style: italic;
+  background: rgba(0, 0, 0, 0.25);
+  box-shadow: inset 0 0 25px rgba(0, 255, 255, 0.08);
+}
+.architect-note {
+  border: 2px solid var(--secondary);
+  border-radius: 12px;
+  padding: 1.5rem;
+  background: rgba(0, 15, 30, 0.85);
+  box-shadow: 0 0 25px rgba(0, 255, 255, 0.25);
+  margin: 2.5rem 0;
+  position: relative;
+}
+.architect-note::before {
+  content: '\2699';
+  position: absolute;
+  top: -18px;
+  left: 15px;
+  font-size: 1.8rem;
+  color: var(--secondary);
+  background: var(--background);
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  box-shadow: 0 0 15px rgba(0, 255, 255, 0.35);
+}
+.architect-note strong {
+  color: var(--secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+section {
+  margin-bottom: 3.5rem;
+}
+.page-numbered {
+  counter-increment: page;
+  position: relative;
+  padding-bottom: 4.5rem;
+}
+
+.page-numbered::after {
+  content: 'Page ' counter(page);
+  position: absolute;
+  bottom: 1rem;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  text-align: center;
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: rgba(0, 255, 255, 0.75);
+  text-shadow: 0 0 12px rgba(0, 255, 255, 0.35);
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(0, 255, 255, 0.25);
+}
+hr {
+  border: none;
+  height: 3px;
+  background: linear-gradient(90deg, rgba(255, 0, 255, 0) 0%, rgba(255, 0, 255, 0.8) 45%, rgba(0, 255, 255, 0.8) 55%, rgba(0, 255, 255, 0) 100%);
+  margin: 3rem 0;
+  box-shadow: 0 0 15px rgba(255, 0, 255, 0.6);
+  position: relative;
+  overflow: hidden;
+}
+hr::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -20%;
+  width: 20%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.9), transparent);
+  animation: pulse 3s infinite;
+}
+@keyframes pulse {
+  0% { left: -20%; }
+  50% { left: 100%; }
+  100% { left: -20%; }
+}
+.table-of-contents {
+  background: rgba(10, 10, 30, 0.9);
+  border: 1px solid rgba(255, 0, 255, 0.3);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 0 25px rgba(0, 255, 255, 0.2);
+}
+.table-of-contents ul {
+  list-style: none;
+  padding: 0;
+}
+.table-of-contents li {
+  margin-bottom: 0.8rem;
+}
+.table-of-contents a {
+  color: var(--accent);
+}
+figure {
+  margin: 2.5rem 0;
+  padding: 2rem;
+  background: rgba(5, 10, 30, 0.9);
+  border: 1px solid rgba(57, 255, 20, 0.25);
+  border-radius: 12px;
+  box-shadow: 0 0 20px rgba(57, 255, 20, 0.2);
+}
+figcaption {
+  text-align: center;
+  font-style: italic;
+  color: rgba(208, 224, 255, 0.8);
+}
+.table-grid {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  border: 1px solid rgba(0, 255, 255, 0.3);
+}
+.table-grid th, .table-grid td {
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  padding: 1rem;
+  text-align: left;
+}
+.table-grid th {
+  background: rgba(0, 255, 255, 0.1);
+  color: var(--secondary);
+}
+.callout-list li strong {
+  color: var(--secondary);
+}
+@media (max-width: 768px) {
+  body {
+    line-height: 1.5;
+  }
+  pre {
+    font-size: 0.9rem;
+  }
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>The Automation Architect</h1>
+  <h2>Building the Self-Scaling Enterprise</h2>
+  <p><strong>A Deep Dive by dim_flows</strong></p>
+  <p>Forget efficiency. We're here to talk about autopoiesis – the art and science of building systems that build themselves. The Genesis Guide showed you the map; this is the masterclass in architecture. We will deconstruct the hype and give you the blueprints to engineer intelligent, autonomous engines of growth. This is not about replacing humans. It's about building titans of industry where human intellect is the spark, and AI is the accelerator. Let's start building.</p>
+  <p>The self-scaling enterprise is not a thought experiment; it is a competitive weapon. Markets are rewired by those who can deploy intelligence faster than rivals can assemble committees. Every paragraph that follows is a challenge to the status quo. You are stepping into a discipline that merges systems thinking, software craftsmanship, and strategic governance. Here we assemble the mental models, the stacks, the operational rituals, and the ethical guardrails that turn automations into adaptive organisms.</p>
+</header>
+<main>
+  <section class="table-of-contents page-numbered">
+    <h3>Table of Contents</h3>
+    <ul>
+      <li><a href="#part1">Part I: The Foundation – Mindset &amp; Strategy</a>
+        <ul>
+          <li><a href="#chapter1">Chapter 1: The Architect's Mindset</a></li>
+          <li><a href="#chapter2">Chapter 2: The Automation Stack: Choosing Your Tools</a></li>
+        </ul>
+      </li>
+      <li><a href="#part2">Part II: The Blueprints – Real-World Applications</a>
+        <ul>
+          <li><a href="#chapter3">Chapter 3: The Autonomous Marketer – Content &amp; Outreach</a></li>
+          <li><a href="#chapter4">Chapter 4: The Sentinel – Social Media &amp; Brand Monitoring</a></li>
+          <li><a href="#chapter5">Chapter 5: The Financial Operator – Algo-Trading &amp; Market Analysis</a></li>
+          <li><a href="#chapter6">Chapter 6: The Hyper-Efficient Operation – Backend &amp; Customer Service</a></li>
+        </ul>
+      </li>
+      <li><a href="#part3">Part III: The Horizon – Future &amp; Ethics</a>
+        <ul>
+          <li><a href="#chapter7">Chapter 7: The Rise of Autonomous Agents</a></li>
+          <li><a href="#chapter8">Chapter 8: The Architect's Ethics</a></li>
+        </ul>
+      </li>
+    </ul>
+  </section>
+  <hr />
+  <section id="part1">
+    <h2>Part I: The Foundation – Mindset &amp; Strategy</h2>
+    <section class="page-numbered" id="chapter1">
+      <h3>Chapter 1: The Architect's Mindset</h3>
+      <h4>From Efficiency to Emergence</h4>
+      <p>You can automate a task and gain a minute. You can automate a process and reclaim an hour. But to architect an autonomous system is to rewire destiny for an entire enterprise. The automation architect does not start with to-do lists, but with value flows, constraints, and opportunity gradients. This chapter reframes your mental model from incremental improvement to exponential orchestration. Efficiency is table stakes; emergence is the endgame. The architect is the choreographer of interactions between humans, algorithms, and infrastructure, cultivating systems that learn, adapt, and compound value with every cycle.</p>
+      <p>Efficiency is a finite game: squeeze costs, cut steps, minimize variance. Emergence is infinite: invite discovery, absorb shocks, amplify signal. When you move from automation as a productivity hack to automation as an architectural discipline, you are no longer satisfied with faster checklists. You design <em>capabilities</em>. You write prompts that encode judgment. You build telemetry pathways that let you see around corners. You anticipate that every agent—human or machine—will bring bias and blind spots, so you design feedback loops that counteract them.</p>
+      <p>This mindset demands <strong>systems literacy</strong>. You interpret the enterprise as an interconnected set of stocks, flows, delays, and feedback loops. Customer acquisition is not a department; it is a flow influenced by brand perception, product experience, and operational reliability. Supply chain resilience is not a procurement KPI; it is a complex adaptive system influenced by geopolitical dynamics, vendor solvency, and logistics algorithms. The automation architect reads these systems the way a conductor reads a score—aware of every instrument, every crescendo, every rest.</p>
+      <h4>First Principles Applied to Enterprise Systems</h4>
+      <p>Begin with <strong>first-principles thinking</strong>. Strip away what the market or your team believes is the way things must operate. Ask: what is the minimal set of truths governing this business domain? For a subscription SaaS, revenue emerges from customer retention, upgrade velocity, and acquisition. For an e-commerce operator, profit emerges from conversion efficiency, margin management, and logistics optimization. First principles do not look like departmental roadmaps; they look like the physics of your enterprise.</p>
+      <p>When you deconstruct your organization into first principles, you begin to see levers hidden beneath bureaucracy. A SaaS support organization may believe that human triage is irreplaceable because every ticket is unique. First principles reveal that ticket resolution is a function of context completeness, decision confidence, and empathy. Context can be automated through data enrichment. Confidence can be achieved through model training on historical outcomes. Empathy can be templated through tone guidelines augmented by sentiment analysis. Suddenly, automation is not about replacing support agents; it is about equipping them with exoskeletons that let them handle ten times the volume with twice the warmth.</p>
+      <p>Apply first principles to investment decisions. Instead of debating whether to buy another marketing tool, ask: what is the equation for our pipeline velocity? Which variables are underperforming? Which constraints are binding? The automation architect uses these equations to justify or reject initiatives. This frames automation not as a cost center but as a strategic lever intimately tied to growth mechanics.</p>
+      <h4>Designing Decision Lattices</h4>
+      <p>Humans make decisions within <em>lattices</em> of context. Every choice reverberates through processes, customers, and regulators. The architect maps these lattices explicitly. Catalog the decisions that drive value: pricing adjustments, lead qualification, fraud detection, content targeting, procurement approvals. For each, note the information required, the tolerable risk, and the acceptable latency. This map becomes your automation blueprint.</p>
+      <p>Once you have the lattice, apply the <strong>Decision Criticality Matrix</strong>. Evaluate impact, variance, data sufficiency, feedback velocity, reversibility, and explainability requirements. High-impact, high-variance decisions might remain human-governed but with AI augmentation that surfaces insights. Low-impact, low-variance decisions are prime candidates for full autonomy. Medium-impact decisions often benefit from <strong>human-in-the-loop</strong> workflows, where AI drafts action plans and humans approve or adjust.</p>
+      <p>The architect engineers <strong>decision support scaffolding</strong>. For every automation candidate, define the decision narrative: who cares, why it matters, what success looks like, what failure costs. Document the cognitive load currently borne by humans. Then design interfaces—dashboards, notifications, review queues—that integrate automation gracefully. The measure of success is not just cycle time but adoption. If humans trust the scaffolding, they will gradually release control, allowing the system to step into full autonomy.</p>
+      <h4>Orchestrating Human-in-the-Loop and Full Autonomy</h4>
+      <p>First-principles thinking also applies to labor. The dichotomy of "automation versus humans" is a shallow frame. The architect's perspective is <strong>Human-in-the-Loop (HITL)</strong> versus <strong>Fully Autonomous (FA)</strong> deployments. HITL is not a compromise; it is a strategic design choice. When regulatory exposure is high, when data quality fluctuates, when brand equity is fragile, the human acts as the ethical governor and storyteller. Fully autonomous systems are justified when latency is mission-critical, when volume overwhelms human bandwidth, or when consistency creates disproportionate value.</p>
+      <p>Build <strong>autonomy ladders</strong>. Stage 0: manual execution with instrumentation. Stage 1: AI-generated recommendations, human execution. Stage 2: AI execution with human oversight and immediate rollback capability. Stage 3: AI execution with periodic human audits. Stage 4: fully autonomous with self-healing and exception handling. Each stage adds telemetry, risk controls, and cultural acclimatization. This prevents the organization from being shocked by sudden autonomy and allows metrics to validate readiness.</p>
+      <p>Design <strong>feedback rituals</strong>. When humans override AI recommendations, capture the rationale. When AI encounters uncertainty, route to humans and log the scenario. This bidirectional learning is how systems evolve from brittle to resilient. Over time, override data becomes training data, and the human shifts from operator to curator.</p>
+      <h4>Risk Architectures and Fallbacks</h4>
+      <p><strong>Risk management</strong> is the quiet partner of innovation. Autonomous systems are probabilistic; they will make mistakes. The architect frames risk across four dimensions: data, decision, execution, and compliance. For each, design mitigation strategies. For data risk, implement anomaly detection on input streams. For decision risk, define guardrails—hard limits on actions without human approval. For execution risk, simulate before deploying. For compliance risk, maintain audit logs and explainability artifacts. Document these strategies in living runbooks accessible to every stakeholder.</p>
+      <p>Consider the <em>Black Box Paradox</em>. Stakeholders fear what they cannot interpret. Your task is to build transparency layers. Maintain decision logs describing inputs, model scores, and rationale. Use model explainability tools (SHAP, LIME) for regulated industries. Provide dashboards that let operations teams pause, adjust, or retrain components. Transparency isn't optional; it's the price of admission for autonomy.</p>
+      <p>Construct <strong>graceful degradation</strong> patterns. When confidence drops below thresholds, switch to simpler heuristics or queue for human review. When upstream systems fail, degrade functionality rather than crashing. Scenario test disaster conditions regularly. Automation without resilience becomes fragility disguised as progress.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Autonomy is a spectrum, not a switch. Design progressive enhancement stages—start with decision support, graduate to partial execution, and only then enable full autonomy. Each stage must include metrics, user feedback, and governance updates. This phased approach compounds trust and reveals hidden dependencies before they become failure points.</p>
+      </div>
+      <h4>Cultural Engineering and Storytelling</h4>
+      <p>The mindset is incomplete without <strong>operational empathy</strong>. Autonomous systems fail when they ignore human workflows. You must understand the lived reality of frontline teams. Sit with support agents to observe how they triage tickets. Shadow marketers as they ideate campaigns. Decode the tacit knowledge embedded in the organization. Only then can you translate intuition into machine-readable logic. Architects who skip this step build brittle solutions that teams quietly bypass.</p>
+      <p>Institutionalize rituals. Weekly <strong>Autonomy Councils</strong> review metrics, incidents, and opportunities. Monthly <strong>Architecture Retrospectives</strong> evaluate how well systems aligned with strategy. Quarterly <strong>Capability Roadmaps</strong> map first principles to upcoming experiments. These rituals shift culture from reactive firefighting to proactive evolution. Storytelling amplifies the transformation: share wins, postmortems, and experiments openly. Celebrate both successful deployments and responsible rollbacks. Culture follows narrative, and the architect authors that narrative.</p>
+      <p>Scenario planning becomes your compass. Envision conservative, transformative, and speculative futures. For each, define the automation capabilities required. Conservative might focus on reporting automation. Transformative might deploy autonomous demand generation. Speculative might design multi-agent ecosystems that negotiate vendor contracts. The architect builds modular infrastructure that can serve all futures without rewrites, preserving optionality while delivering present value.</p>
+      <p>In summary, the architect's mindset fuses visionary ambition with disciplined design. We are not chasing the latest API; we are constructing cognitive infrastructure. The goal is to transform the organization into a <em>learning organism</em>—one that senses, decides, and adapts with minimal friction. Every chapter that follows will refer back to these mental models. When tools change, this mindset anchors you. When competitors scramble to copy features, your architecture evolves faster because it is rooted in principles, not playbooks.</p>
+    </section>
+    <hr />
+    <section class="page-numbered" id="chapter2">
+      <h3>Chapter 2: The Automation Stack: Choosing Your Tools</h3>
+      <h4>The Capability Audit</h4>
+      <p>The architect's canvas is vast. You are not limited to the commercial tool du jour. The automation stack is a layered ecosystem: interface, orchestration, intelligence, infrastructure, governance. Selecting tools is not about brand loyalty; it's about composing capabilities that reinforce your strategic intent. The wrong stack creates spaghetti workflows and technical debt. The right stack becomes a force multiplier. Your first step is a capability audit that surfaces what must be built, what can be bought, and what should be retired.</p>
+      <p>Conduct the audit with ruthless honesty. Inventory every workflow automation, script, integration, and manual process. For each, document owners, business value, failure modes, and dependencies. Classify them into categories: mission-critical, differentiating, legacy, experimental. This map reveals redundancies, hidden single points of failure, and opportunities for consolidation. Architects who skip this step end up layering new tools on top of rotting foundations.</p>
+      <p>From the inventory, derive a <strong>Capability Heatmap</strong>. Rank capabilities such as event ingestion, data transformation, decision intelligence, user experience orchestration, compliance reporting, and telemetry. Score each on maturity and strategic importance. High-importance/low-maturity quadrants are where you invest. Low-importance/high-maturity areas might be candidates for commoditized solutions or even decommissioning. The heatmap is not static; revisit it quarterly as strategy and market dynamics evolve.</p>
+      <h4>Low-Code/No-Code as Rapid Validation Layer</h4>
+      <p><strong>Low-Code/No-Code platforms</strong> like Zapier, Make, Airtable Automations, and n8n democratize experimentation. They excel at connecting SaaS tools, providing visual builders for triggers, conditions, and actions. Their strengths include fast iteration, rich integrations, and non-engineer accessibility. Their weaknesses appear at scale: rate limits, opaque execution environments, limited error handling, and difficulty integrating custom AI models. The automation architect uses these platforms for <em>prototyping intelligence</em>, validating workflows before committing to code.</p>
+      <p>Create a <strong>Rapid Validation Layer</strong> by standardizing how prototypes graduate. Define criteria: performance thresholds, security requirements, integration complexity, cost projections. Once a workflow proves value, hand it to engineering with documentation, event payload examples, and lessons from prototype operation. Translate the logic into infrastructure-as-code pipelines so the production version is reproducible and observable.</p>
+      <p>Mitigate shadow automation by implementing governance even for prototypes. Provide shared workspaces, enforce naming conventions, and integrate monitoring. Instrument prototypes with logging so failures are visible. Encourage business users to document assumptions, dependencies, and fallback plans. This prevents the low-code layer from becoming an unmanageable tangle and ensures knowledge transfer.</p>
+      <h4>Headless Systems and API Orchestration</h4>
+      <p>The future belongs to <strong>headless systems</strong>—services exposed via APIs that you can compose like Lego bricks. REST remains dominant with its resource-oriented paradigm. Webhooks inject reactivity, allowing external systems to notify your engine in real-time. GraphQL adds flexibility by enabling clients to request precisely the data they need. gRPC and event streams deliver high performance for internal microservices. As an architect, you must fluently speak all these protocols and design for change.</p>
+      <p>Implement an <strong>API Gateway</strong> layer that centralizes authentication, rate limiting, request transformation, and observability. Use tools like Kong, AWS API Gateway, or Apigee. Wrap each integration in a service object that abstracts away provider quirks. Instrument calls with tracing (OpenTelemetry) to visualize request flow. Cache responses strategically to reduce cost and latency.</p>
+      <p>For orchestration, blend <strong>stateless compute</strong> (serverless functions) with <strong>stateful workflow engines</strong> (Temporal, AWS Step Functions, Camunda). Stateless compute handles bursty tasks like data enrichment or AI inference. Workflow engines manage long-running processes, retries, compensation logic, and parallel branches. Together they create resilient automation pipelines that can recover from failure and provide audit trails.</p>
+      <p>Embrace <strong>event-driven architecture</strong>. Use message buses (Kafka, NATS, EventBridge) to decouple producers and consumers. Emit domain events (“lead.qualified”, “invoice.paid”, “ticket.escalated”) that other services subscribe to. This decoupling accelerates innovation: new capabilities can listen to events without modifying upstream systems. Ensure events are versioned, schema-validated, and documented to prevent integration drift.</p>
+      <h4>Cloud Infrastructure as Strategic Substrate</h4>
+      <p>The cloud is your substrate. AWS offers breadth, Google Cloud excels at data and AI, Azure integrates deeply with enterprise identity. Multi-cloud is not a virtue in itself; it is a strategy when you need specific strengths or regulatory redundancy. Use <strong>infrastructure as code</strong> (Terraform, Pulumi, AWS CDK) to codify environments. Apply GitOps principles so infrastructure changes are versioned, reviewed, and auditable. Automate environment provisioning for development, staging, and production to ensure parity.</p>
+      <p>Serverless functions embody the automation architect's ethos: elastic, event-driven, cost-aligned. Yet they introduce new considerations: cold starts, execution timeouts, observability. Instrument every function with structured logging, metrics (duration, memory usage), and traces. Pair them with API gateways, queues, and step functions to construct resilient pipelines. Combine with containerized workloads when you need longer execution windows, specialized dependencies, or custom networking.</p>
+      <p>Design for <strong>resilience and compliance</strong>. Implement multi-AZ deployments, backup strategies, and automated failover. Use secrets managers (AWS Secrets Manager, HashiCorp Vault) to protect credentials. Encrypt data at rest and in transit. Tag resources with metadata (owner, environment, cost center) to facilitate governance and cost optimization. Automation isn't only about workflows; it includes the meta-automation that maintains the platform itself.</p>
+      <h4>AI Providers and the Cognitive Layer</h4>
+      <p><strong>Spezialisierte KI-APIs</strong> form the cognitive layer of modern automation. They bring perception, reasoning, and creativity. Consider a diversified portfolio:</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Provider</th>
+            <th>Core Capability</th>
+            <th>Strategic Use</th>
+            <th>Integration Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>OpenAI (GPT-4 family)</td>
+            <td>Natural language understanding &amp; generation</td>
+            <td>Dynamic content creation, decision support, code synthesis</td>
+            <td>Use function calling for structured outputs, manage rate limits via batching, employ RAG for factual grounding.</td>
+          </tr>
+          <tr>
+            <td>Anthropic (Claude 3)</td>
+            <td>Long-context reasoning, safety-focused dialogue</td>
+            <td>Analytical memos, policy analysis, human-in-the-loop reviews</td>
+            <td>Leverage constitutional AI features, maintain context windows efficiently, apply conversation caching.</td>
+          </tr>
+          <tr>
+            <td>Midjourney</td>
+            <td>Generative imagery</td>
+            <td>Marketing creatives, product visualization, concept art</td>
+            <td>Integrate via Discord automation or third-party APIs; manage brand guidelines with prompt templates.</td>
+          </tr>
+          <tr>
+            <td>ElevenLabs</td>
+            <td>AI-generated voice</td>
+            <td>Voice-overs, audio support, brand-aligned narration</td>
+            <td>Pre-generate voice assets, ensure consent for voice clones, embed watermarking.</td>
+          </tr>
+          <tr>
+            <td>RunwayML</td>
+            <td>Video generation &amp; editing</td>
+            <td>Automated video ads, synthetic spokespeople, dynamic storytelling</td>
+            <td>Use asynchronous rendering, manage GPU quota, verify content authenticity.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Orchestrate these AI capabilities through a <strong>model router</strong>. Build a service that receives tasks (summarize, classify, create, simulate) and dispatches them to the appropriate provider based on latency, cost, and performance. Maintain benchmark suites with representative prompts. Log outputs, costs, latency, and user ratings. Use this data to optimize routing and detect degradation. Treat AI providers like interchangeable components even if switching requires prompt adjustments—vendor resilience is strategic resilience.</p>
+      <p>Implement <strong>guardrails</strong> for AI usage. Define content policies, data retention rules, and bias mitigation procedures. Use prompt templates that include compliance instructions. Monitor outputs for toxicity, hallucinations, and drift. When necessary, insert human review steps or use AI moderators to filter responses. Autonomy without guardrails becomes a reputational liability.</p>
+      <h4>Governance, Observability, and Knowledge Flow</h4>
+      <p>Tool selection must consider <strong>governance and observability</strong>. Logging, monitoring, and alerting are not afterthoughts. Instrument your stack with centralized logging (ELK, Datadog, OpenTelemetry). Implement tracing to follow an automation from trigger to completion. Use feature flags to control rollout, and maintain configuration-as-code for reproducibility. Introduce chaos engineering principles—simulate failures, drop messages, throttle APIs. Observe how your system responds. Resilience is designed, not wished for.</p>
+      <p>Apply <strong>policy-as-code</strong>. Tools like Open Policy Agent allow you to encode access rules, data residency constraints, and approval workflows in declarative policies. Evaluate policies during deployment pipelines to prevent non-compliant configurations from reaching production. This merges agility with control, enabling rapid iteration without sacrificing governance.</p>
+      <p>Finally, integrate <strong>knowledge management</strong>. Documentation is part of the stack. Use platforms like Notion, Obsidian, or Confluence to capture system design, decisions, and playbooks. Automate documentation updates: when a workflow changes, trigger a summary that posts to your knowledge base. Create searchable embeddings of your documentation so architects and operators can retrieve answers quickly. Knowledge flow is the circulatory system of the self-scaling enterprise.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Resist the temptation to over-tool. Every new platform introduces surface area for failure. Adopt a <em>minimum viable stack</em> philosophy: add components only when they unlock new capabilities or mitigate critical risk. Conduct quarterly stack reviews to prune redundancy, renegotiate licenses, and align with evolving strategy.</p>
+      </div>
+    </section>
+  </section>
+  <hr />
+  <section id="part2">
+    <h2>Part II: The Blueprints – Real-World Applications</h2>
+    <section class="page-numbered" id="chapter3">
+      <h3>Chapter 3: The Autonomous Marketer – Content &amp; Outreach</h3>
+      <h4>Signals, Scoring, and Creative Intelligence</h4>
+      <p>Marketing is no longer campaign-driven. It is signal-responsive, adaptive, and personalized at scale. The autonomous marketer orchestrates data ingestion, ideation, creation, distribution, and optimization without waiting for weekly stand-ups. This chapter delivers the blueprint for a content engine that perceives market currents and responds with precision. You are designing a perpetual narrative machine fueled by data, tuned by intelligence, and governed by guardrails.</p>
+      <p>The architecture begins with <strong>signal acquisition</strong>. Capture search trends, social chatter, customer feedback, product usage telemetry, sales call transcripts, review sentiment, and competitor moves. Use the Google Trends API, Reddit and Twitter scrapers, App Store review exports, Gong call summaries, and Shopify analytics. Feed them into a central intelligence lake. The objective is to translate raw signals into topics ranked by opportunity score. Build adapters that normalize data into consistent schemas with metadata for source, timestamp, confidence, and persona alignment.</p>
+      <p>The <em>Opportunity Score</em> blends metrics: search volume, audience sentiment, brand relevance, competitive saturation, temporal urgency, margin potential, and cross-channel resonance. Weight each dimension according to strategic priorities. For example, during a product launch, amplify temporal urgency; during a brand-building phase, emphasize sentiment and share of voice. Implement a scoring microservice that recalculates nightly, storing history so you can analyze trend velocity.</p>
+      <p>Visualize the scoring process using a dashboard that highlights trend velocity, personas most interested, and competitor share of voice. Provide manual override controls so strategists can elevate topics aligned with upcoming product releases or partnership announcements. Every override should become training data—the system learns when human intuition surfaced something the data missed.</p>
+      <h4>Structured Ideation and Content Fabrication</h4>
+      <p>Once opportunities are identified, orchestrate <strong>structured ideation</strong>. Deploy GPT-4, Claude 3, or similar models to generate content briefs, outlines, and creative variations. Do not treat them as magic typewriters; treat them as collaborators. Provide prompt templates that include audience persona, tone, distribution channel, historical performance insights, competitive positioning, and compliance constraints. Request structured outputs (JSON) with sections, headlines, supporting points, suggested visuals, and SEO metadata.</p>
+      <p>Example function definition for structured briefs:</p>
+      <pre><code class="language-json">{
+  "name": "generate_content_brief",
+  "description": "Produce a structured brief for multi-channel automation content",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "topic": {"type": "string"},
+      "persona": {"type": "string"},
+      "tone": {"type": "string"},
+      "channels": {"type": "array", "items": {"type": "string"}},
+      "call_to_action": {"type": "string"},
+      "length": {"type": "integer"}
+    },
+    "required": ["topic", "persona", "tone", "channels"]
+  }
+}</code></pre>
+      <p>Break the creative process into phases: ideation, drafting, refinement, localization, and distribution. Each phase is a pipeline stage with quality checks. Ideation outputs briefs. Drafting expands briefs into long-form assets. Refinement involves fact-checking via RAG, compliance reviews, and tone adjustments. Localization adapts content to regional nuances, languages, and cultural references. Distribution packages the asset for each channel.</p>
+      <p>During drafting, pair generative models with structured context. Use retrieval from internal knowledge bases, customer testimonials, case studies, and product specifications. Provide the model with references to cite. Require outputs to include citation placeholders. Use heuristics to detect hallucinations (e.g., references to nonexistent features) and flag for review. Integrate human editors strategically—perhaps only for Tier 1 assets or for regulatory-sensitive industries.</p>
+      <p><strong>Creative Intelligence</strong> also covers visual and audio assets. Use Midjourney or DALL·E to generate imagery based on the brief’s art direction. Use RunwayML to produce video animations. Combine with ElevenLabs to voice narrations. Store assets in a content DAM (Bynder, Storyblok) with metadata linking them to the originating brief and performance metrics. This allows the system to reuse high-performing assets and avoid creative fatigue.</p>
+      <h4>Production Pipelines and Distribution</h4>
+      <p>Automate publishing across web, email, social, and advertising networks. Use CMS APIs (WordPress REST, Webflow, Contentful) to create drafts with structured metadata. Pre-populate canonical URLs, schema markup, internal links, and preview images. For email, integrate with tools like Customer.io or HubSpot to generate segmented campaigns. Use AI to tailor subject lines per segment, testing variations via multi-armed bandits.</p>
+      <p>For social, build channel-specific transformers. A LinkedIn thought leadership post demands a different tone than a TikTok script. Use templated prompts that convert the core message into channel-ready copy. Include hashtag recommendations, mention suggestions, and comment starters to encourage engagement. Schedule posts via platform APIs or tools like Buffer, ensuring compliance with rate limits and platform policies.</p>
+      <p>The blueprint extends to <strong>video content</strong>. Consider the e-commerce TikTok/Reels automation pipeline:</p>
+      <ol>
+        <li><strong>Scraping Reviews:</strong> Use Playwright or Puppeteer to extract latest reviews, capturing rating, sentiment, usage scenario, and customer demographics when available.</li>
+        <li><strong>Summarization:</strong> GPT-4 condenses reviews into highlight statements tagged by emotion, benefit, and objections overcome.</li>
+        <li><strong>Script Generation:</strong> Convert highlights into 15-second script segments with hook, value, social proof, and CTA. Include stage directions, shot suggestions, and overlay text.</li>
+        <li><strong>Visual Assembly:</strong> Send scripts to Synthesia or HeyGen to render avatar-based videos; optionally compile B-roll from product footage via RunwayML.</li>
+        <li><strong>Audio Branding:</strong> Use ElevenLabs to synthesize voiceovers aligned with brand voice. Layer royalty-free or generated music.</li>
+        <li><strong>Distribution:</strong> Upload via TikTok/Instagram APIs, schedule posts, monitor retention analytics, and iterate scripts based on watch-time curves.</li>
+      </ol>
+      <p>Python snippet for the review-to-script pipeline:</p>
+      <pre><code class="language-python">import os
+import requests
+from playwright.sync_api import sync_playwright
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+TARGET_URL = "https://example.com/product-reviews"
+
+PROMPT_CONTEXT = """You are a DTC video producer. Build 20-second TikTok scripts.
+Structure: hook (max 5s), proof (10s), CTA (5s).
+Tone: energetic, authentic, curiosity-driven.
+"""
+
+def scrape_reviews(max_reviews=30):
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(TARGET_URL)
+        page.wait_for_selector('.review-card')
+        reviews = []
+        for review in page.query_selector_all('.review-card')[:max_reviews]:
+            reviews.append({
+                "rating": review.query_selector('.stars').get_attribute('data-score'),
+                "title": review.query_selector('h3').inner_text(),
+                "body": review.query_selector('.content').inner_text(),
+                "persona": review.query_selector('.persona').inner_text() if review.query_selector('.persona') else "unknown"
+            })
+        browser.close()
+        return reviews
+
+def summarize_reviews(reviews):
+    payload = "\n\n".join([
+        f"Rating: {r['rating']}\nPersona: {r['persona']}\nTitle: {r['title']}\nBody: {r['body']}"
+        for r in reviews
+    ])
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": "Summarize reviews into benefit bullets with emotion tags."},
+               {"role": "user", "content": payload}],
+        temperature=0.25,
+        max_output_tokens=900
+    )
+    return [chunk.strip() for chunk in response.output_text.split('\n') if chunk.strip()]
+
+def craft_script(summary):
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": PROMPT_CONTEXT},
+               {"role": "user", "content": summary}]
+    )
+    return response.output_text.strip()
+</code></pre>
+      <p>Integrate with Synthesia:</p>
+      <pre><code class="language-python">SYNTHESIA_API_KEY = os.environ["SYNTHESIA_API_KEY"]
+
+def create_video(script_text, avatar_id="anna"):
+    payload = {
+        "title": "Auto TikTok Ad",
+        "description": "Automated script from customer review",
+        "avatar": avatar_id,
+        "input_text": script_text,
+        "background": "cyberpunk-studio",
+        "aspect_ratio": "9:16"
+    }
+    response = requests.post(
+        "https://api.synthesia.io/v2/videos",
+        headers={"Authorization": f"Bearer {SYNTHESIA_API_KEY}"},
+        json=payload,
+        timeout=30
+    )
+    response.raise_for_status()
+    return response.json()["id"]
+</code></pre>
+      <h4>Lifecycle Personalization and Revenue Alignment</h4>
+      <p>Extend automation beyond content creation. Build lifecycle journeys that adapt to prospect behavior. When a visitor downloads a whitepaper, trigger a nurture sequence tailored to their industry and role. Use AI to craft follow-up emails that reference the content consumed, highlight relevant case studies, and suggest next steps. For product-led growth, analyze in-app actions to generate tooltips, webinars, or offers at the right moment.</p>
+      <p>Integrate marketing automation with CRM. Each lead receives an enrichment payload (company size, tech stack, intent signals) plus a narrative summary generated by AI: pain points inferred, recommended messaging, objections to preempt. Sales development reps enter conversations with context, accelerating conversion. Track how automated touches influence pipeline stages, using attribution models that recognize AI-generated assets.</p>
+      <p>Employ reinforcement learning to optimize sequences. Define reward functions around conversion, retention, or engagement. Allow the system to experiment with send times, frequency, and channel mix. Use Thompson sampling or contextual bandits to balance exploration and exploitation. Provide marketers with dashboards showing experiment status, winners, and guardrails so they remain in control.</p>
+      <p>Finally, integrate <strong>community intelligence</strong>. Monitor Slack communities, Discord servers, and private forums (with permission). Use NLP to detect emerging pains and opportunities. Flag insights for human evangelists. Automation surfaces the conversation; humans join with empathy. This hybrid approach maintains authenticity while scaling coverage.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Authenticity cannot be automated blindly. Embed ethical constraints. Tag AI-generated content explicitly. Use human editors to ensure narratives reflect genuine customer experiences. Design audits that sample output for tone, diversity, and factual accuracy. The goal is augmented authenticity, not synthetic spam.</p>
+      </div>
+    </section>
+    <hr />
+    <section class="page-numbered" id="chapter4">
+      <h3>Chapter 4: The Sentinel – Social Media &amp; Brand Monitoring</h3>
+      <h4>Constructing the Listening Fabric</h4>
+      <p>Your brand is a conversation happening without you unless you deploy sentinels to listen and intervene intelligently. The modern sentinel monitors social streams, classifies sentiment, detects opportunities, and engages with nuance. This chapter designs a system that turns social noise into strategic dialogue. We are building an always-on radar fused with a diplomatic corps that knows when to speak, when to listen, and when to escalate.</p>
+      <p>Begin with the <strong>listening fabric</strong>. Integrate with X (Twitter) APIs, Reddit, LinkedIn, TikTok comments, YouTube transcripts, product review sites, and niche forums. Where APIs are restricted, use compliant scraping with caching and respect for robots.txt. Aggregate data into a streaming pipeline (Kafka, Kinesis) to ensure real-time processing. Normalize payloads into a unified schema capturing text, media links, author metadata, timestamps, engagement metrics, and source reliability.</p>
+      <p>Layer <strong>topic ontologies</strong> on top of raw data. Define taxonomy nodes such as product feedback, competitor comparison, industry news, feature requests, pricing objections, partnership inquiries, and thought leadership. Map keywords, phrases, and semantic embeddings to each node. Use transformer models to classify posts beyond keyword matching. Continuously evolve the ontology by mining new clusters, capturing emergent jargon or memes relevant to your audience.</p>
+      <h4>Analysis and Intent Mapping</h4>
+      <p>As posts flow in, push them into asynchronous processing pipelines. Perform <strong>language detection</strong> and translation where necessary to maintain coverage across regions. Apply sentiment analysis using fine-tuned BERT models for speed and generative models for nuance. Go beyond positive/negative—label emotions like frustration, excitement, curiosity, skepticism. Determine intent: support request, sales inquiry, partnership opportunity, spam, troll, competitor poach.</p>
+      <p>Combine sentiment with <strong>entity resolution</strong>. Cross-reference author handles with CRM contacts, newsletter subscribers, or prospect lists. Use Clearbit or Apollo to enrich corporate affiliations. This transforms a random tweet into an actionable event tied to pipeline data. Prioritize high-value accounts, key influencers, or at-risk customers.</p>
+      <p>Example Python snippet for streaming classification:</p>
+      <pre><code class="language-python">import json
+from openai import OpenAI
+
+client = OpenAI()
+
+CLASSIFICATION_PROMPT = """You are a brand intelligence analyst. \
+Return JSON with sentiment (positive|negative|neutral), intent (complaint|lead|question|praise|spam|other), \
+emotion (joy|anger|confusion|urgency|hope|neutral), and recommended_action (respond|monitor|escalate|ignore)."""
+
+def classify_post(text):
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": CLASSIFICATION_PROMPT},
+               {"role": "user", "content": text}],
+        response_format={"type": "json_object"},
+        temperature=0
+    )
+    return json.loads(response.output_text)
+</code></pre>
+      <p>Implement <strong>anomaly detection</strong>. Use statistical models to identify spikes in negative sentiment, sudden surges in mentions of a product defect, or coordinated bot activity. When anomalies occur, escalate to crisis playbooks with cross-functional stakeholders (PR, legal, product). Provide context snapshots summarizing key posts, top influencers, and recommended responses.</p>
+      <h4>Engagement Automation and Human Oversight</h4>
+      <p>With classification data, orchestrate <strong>response strategies</strong>. Not every mention deserves a reply; some require gratitude, others assistance, and some silence. Encode decision trees that consider sentiment, intent, author influence, and conversation history. When automation responds, ensure transparency and value—offer resources, invite conversations, or escalate gracefully.</p>
+      <p>Example response generator:</p>
+      <pre><code class="language-python">def generate_response(post, classification, knowledge_snippets):
+    persona = {
+        "voice": "Expert, empathetic, futurist",
+        "brand_values": ["transparency", "craftsmanship", "speed"]
+    }
+    context = "\n".join(knowledge_snippets)
+    prompt = (
+        f"Post: {post['text']}\n"
+        f"Sentiment: {classification['sentiment']}\n"
+        f"Intent: {classification['intent']}\n"
+        f"Emotion: {classification['emotion']}\n"
+        f"Persona: {persona}\n"
+        f"Knowledge: {context}\n"
+        "Craft a 280-character response or less, include value, avoid spam, and respect platform etiquette."
+    )
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": "You are the brand's community architect."},
+               {"role": "user", "content": prompt}],
+        temperature=0.4,
+        max_output_tokens=150
+    )
+    return response.output_text.strip()
+</code></pre>
+      <p>Build <strong>approval workflows</strong>. High-risk responses (crisis topics, VIP customers) require human review. Provide moderators with a dashboard showing proposed responses, context, and recommended actions. Capture their edits and decisions as training signals, refining future responses. For low-risk categories, allow autonomous posting with throttling and randomization to avoid detection as bots.</p>
+      <p>Design <strong>playbooks</strong> for recurring scenarios: competitor migration, downtime apology, feature tease, community celebration. Store them as structured templates enriched with dynamic variables. When a relevant event occurs, automation selects the playbook, populates context, and either posts or requests approval. This ensures brand consistency while maintaining agility.</p>
+      <h4>Insight Loops and Crisis Detection</h4>
+      <p>Build dashboards that surface brand health. Track sentiment over time, top topics, influencer mentions, share of voice, and engagement outcomes. Correlate sentiment with product releases, campaign launches, or support incidents. Use BI tools (Mode, Looker) layered on your streaming warehouse to provide executives with real-time brand telemetry.</p>
+      <p>Implement <strong>narrative intelligence</strong>. Summarize weekly social conversations, highlighting emerging themes, unmet needs, and breakout voices. Feed these summaries to product managers, sales leaders, and executives. Align them with Chapter 3’s content engine so new insights become content within hours. Social listening is not a silo; it is the nerve ending that informs every function.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Respect platform policies and ethical boundaries. Automated outreach must comply with anti-spam regulations and community norms. Implement throttling, opt-out mechanisms, and transparency about automation. Build fairness checks to ensure responses do not bias toward or against demographics inadvertently. Trust is the sentinel’s greatest asset.</p>
+      </div>
+    </section>
+    <hr />
+    <section class="page-numbered" id="chapter5">
+      <h3>Chapter 5: The Financial Operator – Algo-Trading &amp; Market Analysis</h3>
+      <h4>Risk Before Reward</h4>
+      <p><strong>Disclaimer:</strong> Automated trading carries significant financial risk. Past performance does not guarantee future results. Deploy any trading system in a simulated environment before risking capital. Understand regulatory obligations in your jurisdiction. Maintain proper oversight and risk controls. The architect designs trading engines with the humility that markets are adversarial, complex, and capable of punishing arrogance instantly.</p>
+      <p>Financial automation tests discipline. Markets are stochastic, multi-agent systems where latency, liquidity, and information asymmetry determine survival. A robust automation architecture balances aggressive opportunity capture with conservative risk governance. We begin by decomposing the trading stack into data acquisition, strategy modeling, execution, risk management, and analytics.</p>
+      <h4>Data Infrastructure and Signal Processing</h4>
+      <p>Data is the lifeblood. Build pipelines for historical and real-time data. For crypto markets, use exchanges like Binance, Coinbase, and Kraken via libraries such as <code>ccxt</code>. For equities, integrate with Alpaca, Polygon.io, or Interactive Brokers. Collect OHLCV (open, high, low, close, volume), order book depth, funding rates, and derivatives data. Store them in time-series databases (TimescaleDB, InfluxDB) with retention policies.</p>
+      <p>Implement <strong>feature engineering</strong> layers. Compute moving averages, Bollinger Bands, RSI, MACD, volume delta, order book imbalance, volatility measures, and on-chain metrics. Use distributed computation (Spark, Dask) if data volume is high. Normalize features, handle missing data, and align by timestamp. Maintain feature catalogs documenting formulas, lags, and use cases.</p>
+      <p>Example OHLCV fetcher:</p>
+      <pre><code class="language-python">import ccxt
+import pandas as pd
+import numpy as np
+import os
+import time
+
+exchange = ccxt.binance({
+    "apiKey": os.environ["BINANCE_KEY"],
+    "secret": os.environ["BINANCE_SECRET"],
+    "enableRateLimit": True
+})
+
+def fetch_ohlcv(symbol="BTC/USDT", timeframe="1m", limit=500):
+    data = exchange.fetch_ohlcv(symbol, timeframe=timeframe, limit=limit)
+    frame = pd.DataFrame(data, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    frame['timestamp'] = pd.to_datetime(frame['timestamp'], unit='ms')
+    return frame
+</code></pre>
+      <h4>Strategy Implementation and Execution</h4>
+      <p>Define strategies ranging from classical indicators to machine learning models. For illustrative purposes, consider an RSI strategy. RSI measures momentum; when below 30, asset is oversold; above 70, overbought. Combine RSI with trend filters (e.g., 200-period moving average) to avoid counter-trend trades. Implement position sizing based on volatility to avoid overexposure.</p>
+      <pre><code class="language-python">def compute_rsi(prices, period=14):
+    delta = prices.diff()
+    gain = np.where(delta > 0, delta, 0)
+    loss = np.where(delta < 0, -delta, 0)
+    avg_gain = pd.Series(gain).rolling(window=period).mean()
+    avg_loss = pd.Series(loss).rolling(window=period).mean()
+    rs = avg_gain / (avg_loss + 1e-9)
+    rsi = 100 - (100 / (1 + rs))
+    return rsi
+
+THRESHOLD_BUY = 30
+THRESHOLD_SELL = 70
+POSITION_SIZE = 0.001
+MAX_DRAWDOWN = 0.05
+
+positions = []
+
+def should_trade(current_price, moving_average):
+    return current_price > moving_average
+
+while True:
+    ohlcv = fetch_ohlcv()
+    closes = ohlcv['close']
+    moving_average = closes.rolling(window=200).mean().iloc[-1]
+    rsi = compute_rsi(closes)
+    latest_rsi = rsi.iloc[-1]
+    price = closes.iloc[-1]
+
+    if latest_rsi < THRESHOLD_BUY and not positions and should_trade(price, moving_average):
+        order = exchange.create_market_buy_order('BTC/USDT', POSITION_SIZE)
+        positions.append({"entry": price, "size": POSITION_SIZE})
+        print(f"Bought at {price}, RSI {latest_rsi}")
+
+    if latest_rsi > THRESHOLD_SELL and positions:
+        order = exchange.create_market_sell_order('BTC/USDT', POSITION_SIZE)
+        entry = positions.pop()
+        pnl = (price - entry['entry']) * entry['size']
+        print(f"Sold at {price}, RSI {latest_rsi}, PnL: {pnl}")
+
+    time.sleep(60)
+</code></pre>
+      <p>This example is simplistic. Production-grade systems incorporate:</p>
+      <ul>
+        <li><strong>Backtesting:</strong> Use libraries like Backtrader or Zipline. Run historical simulations with transaction costs, slippage, and latency assumptions. Evaluate Sharpe ratio, maximum drawdown, win rate, and profit factor.</li>
+        <li><strong>Walk-forward analysis:</strong> Split data into training and validation windows to reduce overfitting.</li>
+        <li><strong>Paper trading:</strong> Connect to exchange sandboxes to validate execution and order handling.</li>
+        <li><strong>Risk controls:</strong> Implement stop-loss, take-profit, trailing stops, and circuit breakers. Limit exposure per asset and per portfolio.</li>
+        <li><strong>Execution algorithms:</strong> Use TWAP/VWAP slicing, smart order routing, and iceberg orders to reduce market impact.</li>
+      </ul>
+      <h4>Risk Governance and Monitoring</h4>
+      <p>Design a <strong>risk engine</strong> that continuously monitors portfolio exposure, value-at-risk (VaR), volatility, and margin requirements. Set global loss limits—if daily drawdown exceeds thresholds, halt trading. Implement kill switches accessible to humans. Maintain audit logs of decisions, orders, and outcomes for compliance.</p>
+      <p>Integrate <strong>anomaly detection</strong> to identify data corruption, exchange downtime, or latency spikes. Use heartbeats and redundancy—if one data provider fails, switch to backups. For mission-critical systems, run redundant instances across regions.</p>
+      <p>Beyond trading, automation powers <strong>market intelligence</strong>. Summarize macro reports, on-chain analytics, and regulatory news. Use AI to parse earnings calls, central bank statements, and social sentiment. Provide dashboards overlaying quantitative metrics with qualitative insights, supporting strategic decisions beyond trading.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Simple bots fail when markets regime-shift. Combine indicator-based strategies with machine learning classification. Use ensemble models to predict trend continuation or reversal, but maintain interpretability. Always pair automation with governance. The best systems stop themselves when the world changes faster than their assumptions.</p>
+      </div>
+    </section>
+    <hr />
+    <section class="page-numbered" id="chapter6">
+      <h3>Chapter 6: The Hyper-Efficient Operation – Backend &amp; Customer Service</h3>
+      <h4>Support Intelligence</h4>
+      <p>The backbone of the self-scaling enterprise is an operational core that anticipates needs, resolves issues, and personalizes experiences. Operations automation is not glamorous, but it is the difference between chaotic scaling and graceful expansion. This chapter outlines systems that streamline support, onboarding, and voice interactions. We design human-centered automation where empathy is amplified, not erased.</p>
+      <p><strong>Intelligent ticket routing</strong> begins with ingestion. Support emails, chats, and calls funnel into a centralized queue via APIs and webhooks. Parse payloads to extract metadata: customer tier, product module, sentiment score, language, and urgency signals (caps lock, exclamation points, keywords). Enrich with CRM context—contract value, usage stats, health score. Store in a structured ticket object.</p>
+      <p>Apply natural language understanding to categorize tickets. Fine-tune transformer models on historical labeled tickets to predict category (billing, technical, onboarding, feedback, account management), priority, and required skill set. Incorporate <strong>routing heuristics</strong>: match enterprise customers with dedicated success managers, route critical outages to on-call engineers, and assign repetitive FAQs to automation bots.</p>
+      <pre><code class="language-python">from pydantic import BaseModel
+from openai import OpenAI
+import json
+
+client = OpenAI()
+
+class Ticket(BaseModel):
+    id: str
+    subject: str
+    body: str
+    customer_tier: str
+    sentiment: float
+
+ROUTING_PROMPT = """You are a support routing AI.
+Categories: billing, technical, onboarding, account_management, feedback, escalation.
+Priorities: low, medium, high, urgent.
+If sentiment < -0.4 or customer_tier == 'enterprise', escalate.
+Return JSON with category, priority, owner_role, recommended_macro."""
+
+def route_ticket(ticket: Ticket):
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": ROUTING_PROMPT},
+               {"role": "user", "content": ticket.model_dump_json()}],
+        response_format={"type": "json_object"}
+    )
+    return json.loads(response.output_text)
+</code></pre>
+      <p>Integrate routing decisions with helpdesk platforms (Zendesk, Freshdesk) via APIs. Attach context: suggested macros, knowledge base links, product telemetry snapshots. Provide agents with AI-generated <strong>briefing cards</strong> summarizing issue, customer history, and recommended resolution steps. Capture agent feedback on accuracy to refine models.</p>
+      <p>Implement <strong>resolution automation</strong> for repetitive tasks. Password resets, invoice requests, plan upgrades—design bots that handle them end-to-end. Use workflow engines to orchestrate steps: verify identity, trigger billing API, send confirmation. Ensure humans can intervene seamlessly when automation hits uncertainty.</p>
+      <h4>Knowledge Ops and Continuous Improvement</h4>
+      <p>Knowledge management is the nervous system. Connect support automation with documentation. When a new issue surfaces, generate draft knowledge articles using AI summarization. Route to subject matter experts for validation. Update chatbots and macros automatically when articles publish. This keeps automation aligned with reality.</p>
+      <p>Track <strong>resolution analytics</strong>: time to first response, time to resolution, deflection rate, customer satisfaction. Use anomaly detection to spot spikes in specific categories. Feed analytics into product teams as early warning signals—support is an early indicator of product issues.</p>
+      <h4>Onboarding Journeys</h4>
+      <p><strong>Automated onboarding</strong> ensures customers reach value quickly. Trigger workflows at signup. Generate personalized onboarding plans using AI, referencing customer goals, industry, and product modules. Sequence emails, in-app walkthroughs, webinars, and check-ins. Use branching logic based on engagement—if the user stalls, send targeted nudges or offer live sessions.</p>
+      <pre><code class="language-python">def build_onboarding_plan(customer):
+    prompt = f"""
+    Customer Profile: {customer}
+    Modules: automation studio, analytics hub, workflow marketplace
+    Objective: Activate first automation within 7 days.
+    Create a 14-day plan with day, action, channel, resource_link, success_metric, fallback.
+    """
+    response = client.responses.create(
+        model="gpt-4.1-mini",
+        input=[{"role": "system", "content": "You are a SaaS onboarding architect."},
+               {"role": "user", "content": prompt}],
+        response_format={"type": "json_object"}
+    )
+    return json.loads(response.output_text)
+</code></pre>
+      <p>Integrate plans with marketing automation and product analytics. When a user completes a milestone, trigger celebratory messages, unlock advanced tutorials, or schedule success manager outreach. When they stall, generate troubleshooting guides or invite them to office hours. Automation becomes a coach, nudging users toward mastery.</p>
+      <h4>Voice Automation and Consent</h4>
+      <p>Voice remains powerful. Use platforms like Bland.ai to conduct automated yet natural-sounding calls for onboarding check-ins, renewal reminders, or satisfaction surveys. Provide dynamic scripts with conditional branches. Record and transcribe calls, then summarize outcomes using AI. Update CRM with sentiment, action items, and follow-up tasks.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Voice automation must respect consent. Offer opt-outs, log permissions, and escalate to humans for complex emotions. Measure sentiment post-call to ensure automation enhances relationships rather than eroding trust.</p>
+      </div>
+      <p>Operations automation extends to <strong>internal tooling</strong>. Build dashboards displaying system health, SLA compliance, backlog trends, and agent workload. Use predictive models to forecast ticket volume based on seasonality, product releases, and usage spikes. Allocate staffing proactively. Automate incident response playbooks—when error rates spike, alert engineering, notify success teams, and update status pages automatically.</p>
+    </section>
+  </section>
+  <hr />
+  <section id="part3">
+    <h2>Part III: The Horizon – Future &amp; Ethics</h2>
+    <section class="page-numbered" id="chapter7">
+      <h3>Chapter 7: The Rise of Autonomous Agents</h3>
+      <p>The frontier of automation is populated by autonomous agents—systems that pursue goals with minimal human oversight. Agents string together perception, planning, execution, and reflection. This chapter explores their architecture, capabilities, and limitations. We design agent ecosystems that behave like self-directed teams with guardrails.</p>
+      <p>Agents such as Auto-GPT, BabyAGI, and ReAct-based frameworks operate by decomposing objectives into subtasks. They leverage large language models to reason, call tools, and evaluate outcomes. The architect defines <strong>agent environments</strong>: available tools, constraints, success criteria, reward functions, and communication protocols.</p>
+      <p>Consider an agent tasked with sourcing top B2B prospects in Germany. The agent’s toolset includes web search APIs, LinkedIn scrapers, enrichment services (Clearbit), email validation APIs, CRM connectors, and outreach templates. The workflow:</p>
+      <ol>
+        <li>Interpret the goal: parse industry focus, company size, buying committee roles.</li>
+        <li>Plan: design a strategy dividing research, enrichment, and outreach phases.</li>
+        <li>Execute: run web searches, scrape data, enrich contacts.</li>
+        <li>Validate: verify emails, deduplicate, ensure compliance with GDPR.</li>
+        <li>Compose: generate personalized outreach referencing research.</li>
+        <li>Review: log actions, produce summary for human approval, dispatch emails via CRM.</li>
+      </ol>
+      <p>Agents maintain memory to avoid redundant work. Use vector databases (Pinecone, Weaviate) to store embeddings of observations, decisions, and results. When the agent receives new instructions, it queries memory for context. Implement short-term memory for immediate tasks and long-term memory for knowledge reuse. Distinguish between episodic memory (what happened) and semantic memory (how to do things).</p>
+      <p>Pseudocode outline:</p>
+      <pre><code class="language-python">class ProspectingAgent:
+    def __init__(self, tools, memory, evaluator):
+        self.tools = tools
+        self.memory = memory
+        self.evaluator = evaluator
+        self.objective = None
+
+    def set_objective(self, objective):
+        self.objective = objective
+        self.memory.store({"type": "objective", "content": objective})
+
+    def plan(self):
+        context = self.memory.retrieve(query=self.objective)
+        plan = llm_plan(objective=self.objective, context=context)
+        self.memory.store({"type": "plan", "content": plan})
+        return plan
+
+    def execute_plan(self, plan):
+        for step in plan:
+            tool = self.tools.select(step)
+            result = tool.run(step)
+            self.memory.store({"type": "observation", "content": result})
+            feedback = self.evaluator.evaluate(step, result)
+            if feedback.requires_adjustment:
+                self.adjust_plan(feedback)
+
+    def adjust_plan(self, feedback):
+        context = self.memory.retrieve_recent()
+        new_plan = llm_replan(objective=self.objective, context=context, feedback=feedback)
+        self.execute_plan(new_plan)
+</code></pre>
+      <p>Agents require <strong>governance</strong>. Define hard constraints: budget limits, domain restrictions, ethical policies. Implement watchdog services that track API calls, time spent, and anomalies. Provide human checkpoints for high-stakes actions (sending emails, executing trades). Log all prompts, actions, and outputs for auditability.</p>
+      <p>Future architectures favor <strong>agent swarms</strong>. Instead of one monolithic agent, deploy specialized agents: research agent gathers data, strategist agent crafts plan, execution agent performs tasks, reviewer agent audits output. Coordinate via an orchestrator that assigns subtasks and reconciles results. Use message queues for communication and apply consensus algorithms to resolve disagreements.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Agents are only as good as their toolboxes. Invest in robust APIs, clean data, and evaluation frameworks. Treat agent design like organizational design—define roles, responsibilities, and escalation paths. Autonomy without structure creates chaos.</p>
+      </div>
+      <p>Current limitations include hallucinations, latency, and cost. Research in tool-augmented models, memory management, and reinforcement learning will enhance reliability. Stay agile by designing agent frameworks with modular components. As models improve, you can swap reasoning engines without rewriting the orchestration layer.</p>
+    </section>
+    <hr />
+    <section class="page-numbered" id="chapter8">
+      <h3>Chapter 8: The Architect's Ethics</h3>
+      <p>Power demands principles. Automation architects wield the ability to reshape workflows, jobs, and societal dynamics. Ethics is not a compliance checkbox; it is a design imperative. This chapter establishes the guardrails that keep innovation aligned with humanity.</p>
+      <p><strong>Bias</strong> is the first adversary. AI models learn from data, and data reflects societal inequities. Conduct bias audits by measuring model performance across demographic groups. Use fairness metrics (equal opportunity difference, demographic parity) to detect disparities. Mitigate through data diversification, reweighting, adversarial training, or post-processing adjustments. Document mitigation steps transparently.</p>
+      <p><strong>Transparency</strong> builds trust. Provide explanations for automated decisions. Use model explainability techniques (SHAP, LIME) and maintain prompt logs for generative systems. Offer users insight into why they received a recommendation or decision. Build interfaces that allow users to contest outcomes and request human review.</p>
+      <p><strong>Privacy</strong> is non-negotiable. Comply with regulations (GDPR, CCPA). Minimize data collection, anonymize when possible, and secure storage with encryption. Implement access controls and audit trails. When scraping public data, respect platform terms and ethical boundaries. When handling sensitive data, apply differential privacy or federated learning.</p>
+      <p><strong>Human impact</strong> matters. Automation alters roles. Engage teams early, communicate purpose, and provide reskilling paths. Use automation to remove drudgery, not dignity. Design dashboards that show how automation supports employees. Celebrate human-machine collaboration successes.</p>
+      <p><strong>Accountability</strong> must be explicit. Define ownership for each automated system—who maintains it, who reviews incidents, who communicates with stakeholders. Establish incident response processes for automation failures. Maintain documentation covering intent, limitations, and monitoring procedures.</p>
+      <div class="architect-note">
+        <p><strong>Architect's Note:</strong> Establish an ethics council. Review new automations for bias, privacy, and societal impact. Conduct pre-mortems imagining how a system could cause harm. Build escalation channels for employees to raise concerns. Ethics is governance in action.</p>
+      </div>
+      <p>Finally, adopt a stewardship mindset. The systems you build will outlive product cycles. Design for auditability, resilience, and adaptability. Teach teams to question, test, and improve. The self-scaling enterprise must also be self-correcting. Innovation without ethics is short-lived; ethical automation compounds value over decades.</p>
+    </section>
+  </section>
+  <hr />
+  <section id="appendix">
+    <section class="page-numbered appendix-intro">
+      <h2>Appendix – Implementation Playbooks</h2>
+      <p>The appendix is your field manual. Each playbook distills operating procedures, templates, and diagnostic checklists so you can translate vision into executable autonomy without breaking cadence. Use these pages as modular inserts into your existing governance and delivery rituals.</p>
+    </section>
+    <section class="page-numbered" id="appendix-a">
+      <h3>Appendix A: Diagnostic Metrics &amp; KPIs</h3>
+      <p>Autonomous systems demand new dashboards. Traditional KPIs like tickets closed or campaigns launched fail to capture adaptive performance. The automation architect curates diagnostic metrics that reveal learning velocity, autonomy confidence, and ecosystem health. This appendix supplies a playbook of metrics and how to instrument them across the enterprise.</p>
+      <p><strong>Autonomy Confidence Score:</strong> Measure how often automated decisions execute without human override, weighted by impact. Track trend over time to ensure confidence grows as models retrain. Sudden drops signal drift or trust erosion.</p>
+      <p><strong>Human Trust Index:</strong> Survey stakeholders monthly. Ask how much they trust the automation to act in their stead, how transparent decisions feel, and whether escalation paths work. Quantify qualitative feedback by tagging themes. Use dashboards to correlate trust with actual performance.</p>
+      <p><strong>Learning Cycle Time:</strong> Calculate duration from anomaly detection to model update deployed. Break into detection, diagnosis, remediation, and validation phases. Short cycles indicate resilient feedback loops. Long cycles reveal bottlenecks in governance or tooling.</p>
+      <p><strong>Coverage Ratio:</strong> For each department, measure proportion of workflows under automation, augmented assistance, or manual operation. Visualize as heatmaps to prioritize investment. Strive for balanced coverage that reflects strategic priorities rather than chasing vanity automation.</p>
+      <p><strong>Ethics Compliance Score:</strong> Track incidents of bias, privacy breaches, or policy violations. Each automation should log compliance checks. Aggregate to monitor ethical health. Pair quantitative counts with qualitative case studies in board reports.</p>
+      <p>Instrumentation tips: integrate metrics into observability stacks (Datadog, Grafana). Use event-driven telemetry—every automation emits structured logs describing decision context, confidence, and outcome. Build automated reports that narrate the state of autonomy weekly for leadership.</p>
+    </section>
+    <section class="page-numbered" id="appendix-b">
+      <h3>Appendix B: Implementation Sprints</h3>
+      <p>Turning vision into shipped autonomy requires disciplined execution. The following sprint structure has been battle-tested across scale-ups and enterprises.</p>
+      <h4>Sprint 0 – Alignment &amp; Groundwork</h4>
+      <p>Objective: Align stakeholders on objectives, success metrics, and guardrails. Activities include mapping current state processes, defining north-star KPIs, assembling cross-functional squads (product, engineering, ops, compliance), and agreeing on documentation standards. Deliverables: charter, RACI matrix, baseline metrics.</p>
+      <h4>Sprint 1 – Sensing &amp; Data Foundations</h4>
+      <p>Objective: Instrument workflows to collect data. Activities: deploy telemetry hooks, integrate data sources, create feature stores, design schemas. Validate data quality via automated tests. Deliverables: data catalog, monitoring dashboards, ingestion runbooks.</p>
+      <h4>Sprint 2 – Prototype &amp; Human Loop</h4>
+      <p>Objective: Build low-code or sandbox prototypes that augment humans. Activities: create AI prompts, integrate with limited datasets, define override mechanisms, collect qualitative feedback. Deliverables: prototype demos, human feedback logs, risk register updates.</p>
+      <h4>Sprint 3 – Harden &amp; Automate</h4>
+      <p>Objective: Translate prototype into production-grade services. Activities: implement orchestration pipelines, integrate authentication, build unit/integration tests, configure monitoring. Conduct tabletop exercises simulating failures. Deliverables: production workflow, observability dashboards, incident response playbook.</p>
+      <h4>Sprint 4 – Scale &amp; Govern</h4>
+      <p>Objective: Expand coverage and embed governance. Activities: set up feature flags, roll out gradually, gather impact metrics, host retrospectives, update documentation, present outcomes to stakeholders. Deliverables: deployment plan, governance board report, backlog of enhancements.</p>
+      <p>Each sprint includes retrospectives focusing on human experience: Did automation reduce toil? Did it surface new insights? Are teams comfortable escalating? Embedding empathy keeps the system aligned with human needs.</p>
+    </section>
+    <section class="page-numbered" id="appendix-c">
+      <h3>Appendix C: Architectural Patterns &amp; Anti-Patterns</h3>
+      <p>Pattern recognition separates elite architects from dabblers. This appendix catalogs recurring patterns that drive success and anti-patterns that sabotage autonomy.</p>
+      <h4>Patterns</h4>
+      <ul>
+        <li><strong>Event-Driven Nervous System:</strong> Every significant state change emits an event. Consumers act asynchronously, promoting loose coupling and resilience.</li>
+        <li><strong>Explainability Layers:</strong> Systems ship with dashboards detailing decision logic, inputs, and outcomes, turning black boxes into glass boxes.</li>
+        <li><strong>Progressive Autonomy:</strong> Deploy autonomy in layers—assistive, supervised, fully autonomous—allowing trust to accumulate.</li>
+        <li><strong>Ethics-by-Design:</strong> Ethical constraints embedded in prompts, policies, and monitoring rather than bolted on later.</li>
+        <li><strong>Knowledge Mesh:</strong> Documentation, prompts, and telemetry flow bi-directionally across teams, preventing information silos.</li>
+      </ul>
+      <h4>Anti-Patterns</h4>
+      <ul>
+        <li><strong>Shadow Automation:</strong> Teams launch ungoverned bots without observability, creating invisible risk.</li>
+        <li><strong>Overfitting to Today:</strong> Architectures optimized for current tools that cannot adapt when providers change.</li>
+        <li><strong>Metric Myopia:</strong> Measuring only cost savings and ignoring strategic impact, leading to short-sighted automation.</li>
+        <li><strong>Heroic Manual Backstops:</strong> Assuming humans will catch failures without giving them tools, context, or time.</li>
+        <li><strong>Documentation Neglect:</strong> Allowing knowledge to live in tribal lore, slowing onboarding and recovery.</li>
+      </ul>
+      <p>For each anti-pattern, prescribe a remediation plan. Shadow automation? Launch an internal registry and require observability hooks. Overfitting? Adopt abstraction layers that let you swap providers. Metric myopia? Tie automations to revenue, retention, and customer experience metrics.</p>
+      <p>Use this appendix as a checklist during architecture reviews. The goal is to sustain momentum without sacrificing reliability or ethics.</p>
+    <section class="page-numbered" id="appendix-d">
+      <h3>Appendix D: Automation Readiness Assessment</h3>
+      <p>Before launching aggressive autonomy programs, assess readiness across culture, data, process, and governance. The following diagnostic survey equips you to identify gaps. Score each dimension from 1 (nascent) to 5 (world-class), then prioritize interventions.</p>
+      <h4>Culture</h4>
+      <ul>
+        <li><strong>Leadership Vision:</strong> Do executives articulate a clear vision for autonomy and allocate resources?</li>
+        <li><strong>Change Resilience:</strong> How does the organization respond to new workflows? Are experimentation rituals in place?</li>
+        <li><strong>Collaboration:</strong> Do cross-functional teams (product, ops, legal) collaborate on automation initiatives?</li>
+        <li><strong>Learning Mindset:</strong> Are retrospectives used to evolve systems? Are failures treated as data?</li>
+      </ul>
+      <h4>Data</h4>
+      <ul>
+        <li><strong>Data Accessibility:</strong> Can teams access clean, well-documented data through governed pipelines?</li>
+        <li><strong>Real-Time Signals:</strong> Are streaming events available for responsive automation?</li>
+        <li><strong>Ground Truth:</strong> Do feedback mechanisms capture outcomes to retrain models?</li>
+        <li><strong>Security &amp; Privacy:</strong> Are controls in place to protect sensitive data during automation?</li>
+      </ul>
+      <h4>Process</h4>
+      <ul>
+        <li><strong>Process Documentation:</strong> Are critical workflows mapped with inputs, outputs, and decision points?</li>
+        <li><strong>Modularity:</strong> Are processes decomposed into reusable components amenable to orchestration?</li>
+        <li><strong>Human-in-the-Loop Design:</strong> Are review and escalation paths defined?</li>
+        <li><strong>Measurement:</strong> Do processes expose KPIs and telemetry for monitoring?</li>
+      </ul>
+      <h4>Governance</h4>
+      <ul>
+        <li><strong>Policy Framework:</strong> Are ethics, compliance, and data policies codified and enforced?</li>
+        <li><strong>Auditability:</strong> Can decisions be traced to inputs and code versions?</li>
+        <li><strong>Incident Response:</strong> Do playbooks exist for automation failures?</li>
+        <li><strong>Talent:</strong> Are there dedicated roles (automation architect, prompt engineer, data steward) accountable for upkeep?</li>
+      </ul>
+      <p>Compile scores into a radar chart. Low scores highlight prerequisites before scaling. Example interventions: if data readiness scores low, invest in data engineering and observability. If governance lags, establish councils and policy automation. Repeat assessments quarterly to track maturity.</p>
+    </section>
+    <section class="page-numbered" id="appendix-e">
+      <h3>Appendix E: Prompt Patterns Library</h3>
+      <p>Prompt engineering is architectural design. This library catalogs patterns that consistently yield reliable outputs from language models when orchestrating automation. Each pattern includes structure, use cases, and pitfalls.</p>
+      <h4>Pattern 1 – Role + Rules + Context + Task</h4>
+      <p><strong>Structure:</strong> Assign the model a role, specify rules, provide context, and define the task. Example:</p>
+      <pre><code class="language-text">Role: You are a compliance analyst.
+Rules: Follow GDPR guidelines, respond with JSON.
+Context: {customer_ticket_details}
+Task: Classify risk level and recommend actions.
+</code></pre>
+      <p><strong>Use cases:</strong> Ticket routing, contract review, risk classification. <strong>Pitfalls:</strong> Forgetting to supply schemas leads to unstructured output.</p>
+      <h4>Pattern 2 – Chain-of-Thought Scaffolding</h4>
+      <p>Encourage deliberate reasoning by prompting the model to think step-by-step before final answers. Use for complex diagnosis or planning. Combine with response_format to ensure final outputs remain structured.</p>
+      <h4>Pattern 3 – Few-Shot with Critique</h4>
+      <p>Provide exemplars followed by a critique of why each is strong. Then request the model to generate a new output and self-critique before finalizing. This improves quality for creative tasks like email personalization or UX copy.</p>
+      <h4>Pattern 4 – Tool Calling Protocol</h4>
+      <p>Define available tools in JSON schema, instruct the model to select tools when needed, and require tool outputs to feed back into reasoning. Essential for agent orchestration.</p>
+      <h4>Pattern 5 – Style Transfer Capsules</h4>
+      <p>Provide style capsules describing tone, vocabulary, rhythm, and emotional cadence. Example capsule for neon-futurist tone: “Tone: visionary, syntax: staccato bursts, imagery: cybernetic, verbs: active, mood: daring.” Attach to prompts to maintain brand voice across channels.</p>
+      <p>Maintain a prompt registry storing version history, performance metrics, and associated automations. Treat prompts as code—review, test, and document.</p>
+    <section class="page-numbered" id="appendix-g">
+      <h3>Appendix G: Governance Templates</h3>
+      <p>Governance is a product, not paperwork. Equip your teams with living templates that make responsible automation the path of least resistance.</p>
+      <h4>Template 1 – Automation Charter</h4>
+      <p><strong>Purpose:</strong> Document why the automation exists, stakeholders, scope, and intended outcomes. Include sections for ethical considerations, data sources, and rollback criteria.</p>
+      <p><strong>Sections:</strong> Executive summary, problem statement, desired outcomes, KPIs, human roles, autonomy stage, risk assessment, compliance review, communication plan.</p>
+      <h4>Template 2 – Decision Log</h4>
+      <p>Maintain a running log capturing every major decision with date, owner, rationale, and evidence. Link to supporting documents and experiments. Encourage teams to revisit decisions quarterly.</p>
+      <h4>Template 3 – Incident Report</h4>
+      <p>When automation misbehaves, run blameless postmortems. Template fields: summary, timeline, impact, root cause, contributing factors, detection method, containment actions, long-term remediation, lessons learned, follow-up tasks. Include section for customer communication.</p>
+      <h4>Template 4 – Ethics Checklist</h4>
+      <p>Checklist items: data minimization, consent, bias assessment, explainability, audit logging, human escalation, kill switch tested, documentation updated. Require sign-off from responsible AI officers or councils.</p>
+      <p>Host these templates in collaborative tools (Notion, Confluence) with automation to pre-populate sections from telemetry. For example, generate initial incident timelines automatically from logs.</p>
+    </section>
+    </section>
+    <section class="page-numbered" id="appendix-f">
+      <h3>Appendix F: Case Studies from the Field</h3>
+      <p>Theory becomes conviction when tested. The following case studies illustrate how automation architects deployed systems that transformed operations.</p>
+      <h4>Case Study 1 – Global SaaS Support</h4>
+      <p>Challenge: A SaaS company with 30k customers faced rising support backlogs. Approach: Deployed intelligent routing, AI-generated summaries, and automated knowledge creation. Results: First-response time dropped 60%, customer satisfaction rose 12 points, and agents spent 35% more time on high-touch escalations. Key insight: Human trust increased when dashboards explained AI decisions.</p>
+      <h4>Case Study 2 – Autonomous B2B Marketing Engine</h4>
+      <p>Challenge: A B2B fintech lacked consistent top-of-funnel demand. Approach: Built signal-to-content pipeline (Google Trends, CRM data, GPT-4 outlines, CMS automation). Integrated reinforcement learning to optimize send times. Results: 4x content output, 28% increase in qualified pipeline, marketing team redeployed to strategic partnerships. Key insight: Transparent prompt registry enabled compliance sign-off.</p>
+      <h4>Case Study 3 – Mid-Market Manufacturing Ops</h4>
+      <p>Challenge: Paper-heavy procurement process caused delays. Approach: Digitized documents, built NLP classifiers to extract purchase intents, orchestrated approvals via serverless workflows, embedded human oversight for large orders. Results: Cycle time reduced from 21 days to 6, error rate dropped 70%, savings redirected to R&amp;D. Key insight: Human change management sessions were as critical as code.</p>
+      <p>Lessons learned across cases: start with instrumentation, invest in explainability, and treat automation as culture change. Celebrate human-machine wins publicly to reinforce adoption.</p>
+    </section>
+    <section class="page-numbered" id="appendix-h">
+      <h3>Appendix H: Technology Stack Matrix</h3>
+      <p>Choosing tools is an ongoing calculus. The matrix below helps evaluate platforms across dimensions of scalability, extensibility, cost, and governance. Customize weights to mirror strategic priorities.</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Option</th>
+            <th>Strengths</th>
+            <th>Limitations</th>
+            <th>Architect Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Workflow Orchestration</td>
+            <td>Temporal</td>
+            <td>Code-first workflows, durable execution, visibility via Web UI</td>
+            <td>Requires developer expertise, self-host or managed cost</td>
+            <td>Ideal for mission-critical workflows needing retries and versioning.</td>
+          </tr>
+          <tr>
+            <td>Workflow Orchestration</td>
+            <td>Zapier</td>
+            <td>Fast prototyping, extensive integrations, low barrier</td>
+            <td>Limited control, rate limits, opaque debugging</td>
+            <td>Use for experiments, migrate to headless platforms for scale.</td>
+          </tr>
+          <tr>
+            <td>Data Warehouse</td>
+            <td>BigQuery</td>
+            <td>Serverless, elastic, strong ML integrations</td>
+            <td>Cost management requires partitioning discipline</td>
+            <td>Pair with dbt for modeling, use Looker or Hex for insights.</td>
+          </tr>
+          <tr>
+            <td>Observability</td>
+            <td>Datadog</td>
+            <td>Unified metrics, traces, logs, AI anomaly detection</td>
+            <td>Cost scales rapidly with volume</td>
+            <td>Tag automation components to isolate performance signals.</td>
+          </tr>
+          <tr>
+            <td>Model Serving</td>
+            <td>LangChain + OpenAI</td>
+            <td>Rapid chaining, tool integration, community ecosystem</td>
+            <td>Abstraction overhead, requires governance wrappers</td>
+            <td>Wrap with custom evaluators and telemetry for reliability.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Decision workflow: score each option 1-5 across criteria (scalability, flexibility, governance, cost). Multiply by weights (e.g., 0.35, 0.25, 0.2, 0.2). Document rationale and revisit quarterly as vendors evolve. Maintain exit strategies—define how to migrate if pricing or reliability shifts.</p>
+    </section>
+    <section class="page-numbered" id="appendix-i">
+      <h3>Appendix I: Frequently Asked Questions</h3>
+      <p>Address recurring questions to accelerate adoption.</p>
+      <h4>“How do we ensure humans stay relevant?”</h4>
+      <p>Design roles that move humans up the value chain. Automate toil, not expertise. Create new roles: automation curator, narrative strategist, ethics steward. Offer reskilling paths and celebrate human creativity in symbiosis with AI.</p>
+      <h4>“What if regulators change the rules?”</h4>
+      <p>Build policy agility. Encode regulations as policy-as-code. Maintain compliance sandboxes to test updates. Keep legal counsel embedded in autonomy councils. Document decision logic for audits.</p>
+      <h4>“How do we measure ROI?”</h4>
+      <p>Blend quantitative (revenue, cost, speed) with qualitative (employee satisfaction, customer delight). Track leading indicators like learning cycle time and trust index alongside lagging financial metrics.</p>
+      <h4>“When should we stop automating?”</h4>
+      <p>Stop when marginal benefit falls below marginal complexity. If autonomy reduces resilience or erodes trust, pause and reevaluate. Maintain a backlog of manual wins worth preserving for human craftsmanship.</p>
+      <h4>“What talent do we hire?”</h4>
+      <p>Recruit hybrid thinkers: systems engineers with product empathy, data scientists who understand operations, compliance experts fluent in AI. Upskill existing staff through labs, pair programming, and community practice.</p>
+      <p>Use this FAQ as onboarding material for executives, managers, and frontline teams embarking on autonomy initiatives.</p>
+    <section class="page-numbered" id="appendix-j">
+      <h3>Appendix J: Change Management Playbook</h3>
+      <p>Automation fails without hearts and minds. Deploy change management as deliberately as code deployments.</p>
+      <h4>Principle 1 – Radical Transparency</h4>
+      <p>Communicate the why, the how, and the guardrails. Host town halls, publish FAQs, and share architecture diagrams. Highlight how autonomy augments roles, not replaces them. Share success metrics openly.</p>
+      <h4>Principle 2 – Champions Network</h4>
+      <p>Recruit champions from every department. Train them early, give them sandbox access, and empower them to collect feedback. Champions translate vision into local language and surface resistance before it festers.</p>
+      <h4>Principle 3 – Progressive Exposure</h4>
+      <p>Roll out automation in cohorts. Start with volunteers, then expand. Provide opt-out paths initially to build psychological safety. Celebrate milestones with storytelling—show the humans behind the automation.</p>
+      <h4>Principle 4 – Skill Uplift</h4>
+      <p>Invest in training programs: prompt engineering workshops, data literacy bootcamps, governance clinics. Provide certifications and badges to recognize new competencies.</p>
+      <h4>Principle 5 – Feedback Everywhere</h4>
+      <p>Embed feedback channels into tools. Use in-product surveys, Slack bots, and office hours. Respond quickly, adjust roadmaps, and close the loop so contributors feel heard.</p>
+      <p>Change management is continuous. Review sentiment data monthly and adjust tactics.</p>
+    </section>
+    <section class="page-numbered" id="appendix-k">
+      <h3>Appendix K: Security &amp; Compliance Framework</h3>
+      <p>Security cannot be bolted on. Design with the assumption that automation expands attack surfaces.</p>
+      <ul>
+        <li><strong>Zero Trust Foundations:</strong> Authenticate every call. Use short-lived tokens, scoped permissions, and secrets rotation.</li>
+        <li><strong>Data Classification:</strong> Tag data assets (public, internal, confidential, restricted). Enforce policies on where each class can flow.</li>
+        <li><strong>Audit Logging:</strong> Log every automated action with timestamp, actor (human or bot), input references, and outcomes. Store in immutable systems.</li>
+        <li><strong>Vulnerability Management:</strong> Include automation services in patch cycles. Run dependency scans, penetration tests, and threat modeling exercises.</li>
+        <li><strong>Third-Party Risk:</strong> Evaluate vendors for SOC2, ISO 27001, data residency. Maintain exit plans and monitor SLA adherence.</li>
+      </ul>
+      <p>Compliance integration: automate evidence collection for audits. Generate compliance reports showing access logs, incident responses, and policy adherence. Work with legal to update privacy notices as automation evolves.</p>
+    </section>
+    <section class="page-numbered" id="appendix-l">
+      <h3>Appendix L: Glossary of Architectural Vocabulary</h3>
+      <p>Language aligns teams. Use this glossary to ensure shared understanding.</p>
+      <ul>
+        <li><strong>Autonomy Ladder:</strong> Staged progression from manual to fully autonomous execution.</li>
+        <li><strong>Decision Lattice:</strong> Map of interconnected decisions with dependencies and impacts.</li>
+        <li><strong>Feedback Velocity:</strong> Speed at which outcomes are observed and integrated into system adjustments.</li>
+        <li><strong>Model Router:</strong> Service that dispatches tasks to different AI models based on criteria.</li>
+        <li><strong>Runbook Automation:</strong> Codified procedures executed autonomously to remediate incidents.</li>
+        <li><strong>Trust Index:</strong> Composite metric reflecting stakeholder confidence in automation.</li>
+        <li><strong>Ethics Council:</strong> Multidisciplinary group governing responsible automation.</li>
+      </ul>
+      <p>Extend the glossary as new concepts emerge. Align documentation, training, and dashboards to this vocabulary.</p>
+    </section>
+    <section class="page-numbered" id="appendix-m">
+      <h3>Appendix M: Autonomy Maturity Roadmap</h3>
+      <p>Track progress across five maturity stages. Use this roadmap to align executive expectations and plan investments.</p>
+      <ol>
+        <li><strong>Stage 1 – Instrumented Awareness:</strong> Basic telemetry captures manual processes. Dashboards surface bottlenecks. Focus: data hygiene, process mapping.</li>
+        <li><strong>Stage 2 – Augmented Assistance:</strong> AI offers recommendations while humans execute. HITL loops collect training data. Focus: prompt design, human feedback capture.</li>
+        <li><strong>Stage 3 – Managed Autonomy:</strong> Systems execute within guardrails, humans supervise exceptions. Focus: workflow orchestration, guardrail enforcement, trust dashboards.</li>
+        <li><strong>Stage 4 – Adaptive Autonomy:</strong> Models self-improve with minimal human input. Experimentation platforms run constant A/B tests. Focus: evaluation frameworks, policy automation.</li>
+        <li><strong>Stage 5 – Autopoietic Enterprise:</strong> Automation designs new automations, guided by human governance. Agents coordinate across departments. Focus: meta-learning, ethics governance, scenario planning.</li>
+      </ol>
+      <p>For each stage, define milestones, required capabilities, and organizational changes. Example: to progress from Stage 2 to Stage 3, you need event-driven infrastructure, explainability tooling, and governance councils.</p>
+    </section>
+    <section class="page-numbered" id="appendix-n">
+      <h3>Appendix N: Experimentation Framework</h3>
+      <p>Autonomous systems thrive on experimentation. Structure experiments to generate reliable insights.</p>
+      <ul>
+        <li><strong>Hypothesis Library:</strong> Maintain backlog of hypotheses linking interventions to outcomes. Example: “If we personalize onboarding emails with GPT-4, activation rate will increase by 10%.”</li>
+        <li><strong>Experimental Design:</strong> Define control and treatment groups, sample size, duration, success metrics, and guardrails. Use sequential testing methods to detect significance early without false positives.</li>
+        <li><strong>Automation:</strong> Automate experiment setup via infrastructure-as-code. Deploy feature flags, logging, and monitoring automatically.</li>
+        <li><strong>Analysis:</strong> Use statistical notebooks (Hex, Jupyter) with pre-built templates. Calculate uplift, confidence intervals, and effect sizes. Visualize results in executive-ready formats.</li>
+        <li><strong>Knowledge Capture:</strong> After each experiment, record learnings in a knowledge base. Tag by domain, audience, and success level. Feed insights into future prompt and workflow design.</li>
+      </ul>
+      <p>Institutionalize experimentation ceremonies: weekly triage to prioritize hypotheses, monthly review to harvest insights, quarterly summits to align roadmaps.</p>
+    </section>
+    <section class="page-numbered" id="appendix-o">
+      <h3>Appendix O: Vendor Negotiation Guide</h3>
+      <p>Vendors supply critical capabilities. Negotiate intelligently to secure flexibility, compliance, and innovation.</p>
+      <h4>Negotiation Pillars</h4>
+      <ul>
+        <li><strong>Usage Transparency:</strong> Request detailed usage dashboards to monitor costs and performance.</li>
+        <li><strong>Roadmap Alignment:</strong> Share your autonomy roadmap, ask for theirs. Negotiate influence on features and SLAs.</li>
+        <li><strong>Exit Clauses:</strong> Ensure portability of data and configurations. Negotiate assistance during migration.</li>
+        <li><strong>Security Guarantees:</strong> Demand compliance certifications, incident response commitments, and breach notification SLAs.</li>
+        <li><strong>Co-Innovation Credits:</strong> Seek joint marketing opportunities, beta access, or dedicated solution architects.</li>
+      </ul>
+      <p>Create negotiation scorecards rating vendors on compliance, performance, pricing, roadmap, and support. Revisit annually.</p>
+    </section>
+    <section class="page-numbered" id="appendix-p">
+      <h3>Appendix P: KPI Dashboard Blueprint</h3>
+      <p>A cohesive dashboard keeps leadership focused on the right signals. Blueprint sections:</p>
+      <ul>
+        <li><strong>Autonomy Overview:</strong> Pie chart of workflows by autonomy stage, trend lines of autonomy confidence, trust index gauge.</li>
+        <li><strong>Impact Metrics:</strong> Time saved, revenue influenced, cost avoided. Display as rolling 90-day sums.</li>
+        <li><strong>Quality Metrics:</strong> Override rate, false positive rate, incident count by severity.</li>
+        <li><strong>Experimentation Velocity:</strong> Number of experiments run, win rate, cumulative uplift.</li>
+        <li><strong>Ethics &amp; Compliance:</strong> Bias audits completed, privacy incidents, compliance score.</li>
+      </ul>
+      <p>Implement with BI tools and embed into exec briefings. Add drill-downs for each department to explore specifics.</p>
+    </section>
+    <section class="page-numbered" id="appendix-q">
+      <h3>Appendix Q: Organizational Roles &amp; Operating Model</h3>
+      <p>Autonomy demands new roles and operating rhythms.</p>
+      <ul>
+        <li><strong>Automation Architect:</strong> Designs system end-to-end, aligns strategy with tooling, chairs autonomy council.</li>
+        <li><strong>Prompt Engineer:</strong> Crafts prompts, evaluates outputs, maintains prompt registry.</li>
+        <li><strong>Data Product Manager:</strong> Owns data quality, feature stores, and analytics roadmaps.</li>
+        <li><strong>Governance Lead:</strong> Oversees policies, ethics reviews, and compliance automation.</li>
+        <li><strong>Automation Ops Engineer:</strong> Maintains infrastructure, monitors health, and responds to incidents.</li>
+        <li><strong>Change Strategist:</strong> Manages communication, training, and adoption programs.</li>
+      </ul>
+      <p>Operating rhythms: weekly autonomy syncs, monthly portfolio reviews, quarterly architecture summits. Encourage cross-functional rotations to diffuse knowledge.</p>
+    </section>
+    <section class="page-numbered" id="appendix-r">
+      <h3>Appendix R: Future Scenarios &amp; Strategic Bets</h3>
+      <p>Prepare for multiple futures. Develop scenario narratives:</p>
+      <ol>
+        <li><strong>Scenario Alpha – Regulation Surge:</strong> Governments impose strict AI controls. Strategy: invest in explainability, maintain auditable logs, build compliance accelerators.</li>
+        <li><strong>Scenario Beta – Agent Ecosystems:</strong> Multi-agent platforms dominate. Strategy: develop agent marketplaces, invest in interoperability, cultivate tool ecosystems.</li>
+        <li><strong>Scenario Gamma – Workforce Renaissance:</strong> Human creativity becomes premium. Strategy: redirect automation savings into innovation labs, co-create with customers, elevate human craftsmanship.</li>
+      </ol>
+      <p>For each scenario, define trigger signals, strategic moves, and automation adjustments. Update annually.</p>
+    </section>
+    <section class="page-numbered" id="appendix-s">
+      <h3>Appendix S: AI Evaluation Metrics</h3>
+      <p>Evaluate models with rigor. Key metrics:</p>
+      <ul>
+        <li><strong>Task Success Rate:</strong> Percentage of outputs meeting predefined acceptance criteria.</li>
+        <li><strong>Calibration:</strong> Alignment between model confidence and actual correctness.</li>
+        <li><strong>Consistency:</strong> Variance in outputs for identical prompts over time.</li>
+        <li><strong>Latency:</strong> Response time distributions under load.</li>
+        <li><strong>Cost per Decision:</strong> Spend per inference relative to value generated.</li>
+        <li><strong>Bias Indicators:</strong> Disparities across demographic segments.</li>
+      </ul>
+      <p>Implement automated evaluation pipelines: synthetic test sets, human review samples, and continuous monitoring dashboards.</p>
+    </section>
+    <section class="page-numbered" id="appendix-t">
+      <h3>Appendix T: Integration Testing Checklist</h3>
+      <p>Before promoting automations, execute this checklist:</p>
+      <ol>
+        <li>Validate input schemas against live data.</li>
+        <li>Run unit tests for each function and API interaction.</li>
+        <li>Simulate failure scenarios: API downtime, malformed data, rate limits.</li>
+        <li>Verify logging, metrics, and alerts fire correctly.</li>
+        <li>Confirm security controls: authentication, authorization, secret management.</li>
+        <li>Conduct end-to-end rehearsal including human escalation.</li>
+      </ol>
+      <p>Document results and obtain sign-offs before deploying to production.</p>
+    </section>
+    <section class="page-numbered" id="appendix-u">
+      <h3>Appendix U: Community &amp; Ecosystem Strategy</h3>
+      <p>Autonomy thrives in ecosystems. Build community strategies:</p>
+      <ul>
+        <li><strong>Internal Guilds:</strong> Create guilds for automation architects, prompt engineers, and operations analysts to share patterns.</li>
+        <li><strong>External Partnerships:</strong> Collaborate with universities, research labs, and vendors on pilots.</li>
+        <li><strong>Open Knowledge:</strong> Publish case studies, contribute to open-source libraries, and host meetups.</li>
+        <li><strong>Customer Advisory Boards:</strong> Invite customers to co-design automations, gathering feedback for roadmap.</li>
+      </ul>
+      <p>Community accelerates learning and positions your enterprise as a thought leader.</p>
+    </section>
+    <section class="page-numbered" id="appendix-v">
+      <h3>Appendix V: Automation Budgeting Model</h3>
+      <p>Budget strategically. Build models capturing:</p>
+      <ul>
+        <li><strong>CapEx vs OpEx:</strong> Infrastructure investments versus consumption-based AI fees.</li>
+        <li><strong>Talent Costs:</strong> Salaries for architects, engineers, analysts, governance leads.</li>
+        <li><strong>Change Management:</strong> Training, communication, and adoption programs.</li>
+        <li><strong>Risk Mitigation:</strong> Insurance, compliance, legal reviews.</li>
+        <li><strong>Innovation Fund:</strong> Experiments, pilots, community contributions.</li>
+      </ul>
+      <p>Model ROI by projecting revenue uplift, cost savings, churn reduction, and opportunity value. Scenario plan for conservative, expected, and aggressive outcomes.</p>
+    </section>
+    <section class="page-numbered" id="appendix-w">
+      <h3>Appendix W: Training Curriculum</h3>
+      <p>Develop a curriculum to elevate the entire organization.</p>
+      <ol>
+        <li><strong>Automation Foundations:</strong> Systems thinking, autonomy ladder, governance principles.</li>
+        <li><strong>Data Literacy:</strong> Reading dashboards, understanding metrics, basic SQL.</li>
+        <li><strong>Prompt Mastery:</strong> Prompt templates, evaluation methods, prompt debugging.</li>
+        <li><strong>Tool Labs:</strong> Hands-on sessions with orchestration tools, vector databases, monitoring stacks.</li>
+        <li><strong>Ethics Workshops:</strong> Bias awareness, privacy design, responsible communication.</li>
+        <li><strong>Leadership Clinics:</strong> Strategic planning with autonomy, portfolio prioritization.</li>
+      </ol>
+      <p>Offer learning paths by role and track progress with badges. Encourage communities of practice to reinforce skills.</p>
+    </section>
+    <section class="page-numbered" id="appendix-x">
+      <h3>Appendix X: Risk Heatmap Methodology</h3>
+      <p>Visualize risk to prioritize safeguards.</p>
+      <ol>
+        <li>List automation initiatives with descriptions and stakeholders.</li>
+        <li>Score each on impact (financial, reputational), likelihood, detectability, and recoverability.</li>
+        <li>Plot on heatmap (likelihood vs impact). Color-code by detectability.</li>
+        <li>Define mitigation actions: additional guardrails, human oversight, simulation plans.</li>
+        <li>Review quarterly with governance council and adjust scores based on incidents.</li>
+      </ol>
+      <p>Use risk heatmaps to prioritize audits and allocate contingency budgets.</p>
+    </section>
+    <section class="page-numbered" id="appendix-y">
+      <h3>Appendix Y: AI Policy Blueprint</h3>
+      <p>Draft policies that translate values into guardrails.</p>
+      <ul>
+        <li><strong>Purpose Statement:</strong> Define why automation exists and the principles guiding development.</li>
+        <li><strong>Scope:</strong> Clarify systems, data, and teams covered.</li>
+        <li><strong>Data Governance:</strong> Outline data collection, retention, minimization, and consent requirements.</li>
+        <li><strong>Model Management:</strong> Specify evaluation, versioning, deployment, and retirement criteria.</li>
+        <li><strong>Human Oversight:</strong> Detail approval workflows, escalation paths, and override rights.</li>
+        <li><strong>Incident Response:</strong> Describe detection, communication, and remediation protocols.</li>
+        <li><strong>Transparency:</strong> Commit to user disclosures and documentation standards.</li>
+      </ul>
+      <p>Review policies annually with legal, compliance, and community stakeholders.</p>
+    </section>
+    <section class="page-numbered" id="appendix-z">
+      <h3>Appendix Z: Post-Launch Review Framework</h3>
+      <p>After launch, conduct structured reviews.</p>
+      <ol>
+        <li><strong>Metric Review:</strong> Compare actual results with projections. Highlight deltas.</li>
+        <li><strong>User Feedback:</strong> Summarize qualitative insights from operators and customers.</li>
+        <li><strong>Incident Analysis:</strong> Document outages, overrides, and near misses.</li>
+        <li><strong>Process Adjustments:</strong> Update runbooks, prompts, and guardrails.</li>
+        <li><strong>Next Iteration:</strong> Define backlog items, experiments, and training needs.</li>
+      </ol>
+      <p>Post-launch reviews institutionalize continuous improvement.</p>
+    </section>
+    <section class="page-numbered" id="appendix-aa">
+      <h3>Appendix AA: Reference Architecture Narrative</h3>
+      <p>Describe a canonical architecture from signal to action:</p>
+      <ol>
+        <li><strong>Signal Layer:</strong> Event bus captures triggers from webhooks, IoT devices, and user actions.</li>
+        <li><strong>Ingestion Layer:</strong> Stream processors validate, enrich, and route events to data lake and feature store.</li>
+        <li><strong>Intelligence Layer:</strong> Model router dispatches tasks to GPT-4, Claude, or custom models with retrieval augmentation.</li>
+        <li><strong>Orchestration Layer:</strong> Temporal workflows coordinate tasks, handle retries, and manage human approvals.</li>
+        <li><strong>Execution Layer:</strong> Microservices or RPA bots enact decisions via APIs or legacy systems.</li>
+        <li><strong>Observability Layer:</strong> Metrics, logs, and traces feed dashboards, anomaly detectors, and alerting.</li>
+        <li><strong>Governance Layer:</strong> Policy engine enforces compliance, and audit store logs every decision.</li>
+      </ol>
+      <p>Document architecture diagrams and keep them updated as systems evolve.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ab">
+      <h3>Appendix AB: Vendor Scorecard Template</h3>
+      <p>Standardize vendor evaluations to avoid biased decisions.</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Criteria</th>
+            <th>Description</th>
+            <th>Weight</th>
+            <th>Score (1-5)</th>
+            <th>Weighted Score</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Compliance</td>
+            <td>Certifications, data residency, regulatory alignment</td>
+            <td>0.25</td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Performance</td>
+            <td>Latency, uptime, scalability benchmarks</td>
+            <td>0.20</td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Innovation</td>
+            <td>Roadmap transparency, co-innovation opportunities</td>
+            <td>0.15</td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Cost</td>
+            <td>Pricing structure, predictability, ROI potential</td>
+            <td>0.20</td>
+            <td></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>Support</td>
+            <td>Customer success, technical support, response time</td>
+            <td>0.20</td>
+            <td></td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Sum weighted scores to compare vendors objectively.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ac">
+      <h3>Appendix AC: KPI Formulas Reference</h3>
+      <p>Document formulas to ensure consistent reporting.</p>
+      <ul>
+        <li><strong>Automation ROI:</strong> (Value Generated – Total Automation Cost) / Total Automation Cost.</li>
+        <li><strong>Cycle Time Reduction:</strong> (Baseline Duration – Automated Duration) / Baseline Duration.</li>
+        <li><strong>Adoption Rate:</strong> Automated Transactions / Total Eligible Transactions.</li>
+        <li><strong>Override Rate:</strong> Manual Overrides / Automated Decisions.</li>
+        <li><strong>Learning Velocity:</strong> Model Updates per Month / Active Automations.</li>
+      </ul>
+      <p>Include KPI definitions in analytics documentation to avoid interpretation drift.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ad">
+      <h3>Appendix AD: Implementation Timeline Example</h3>
+      <p>Example 180-day timeline for launching an autonomous marketing engine:</p>
+      <ol>
+        <li>Days 1-30: Capability audit, data ingestion, stakeholder alignment.</li>
+        <li>Days 31-60: Prototype content generation, human feedback loops.</li>
+        <li>Days 61-90: Build production pipelines, integrate CMS, set up observability.</li>
+        <li>Days 91-120: Roll out to pilot segments, run experiments, refine prompts.</li>
+        <li>Days 121-150: Expand channels (email, social, video), implement reinforcement learning.</li>
+        <li>Days 151-180: Conduct post-launch review, add governance metrics, plan next phase.</li>
+      </ol>
+      <p>Customize timeline per domain but maintain explicit milestones.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ae">
+      <h3>Appendix AE: Compliance Audit Checklist</h3>
+      <p>Prepare for audits proactively.</p>
+      <ol>
+        <li>Inventory all automations with data classifications and owners.</li>
+        <li>Verify documentation: policies, runbooks, decision logs, risk assessments.</li>
+        <li>Review access controls and least-privilege configurations.</li>
+        <li>Ensure audit logs are immutable, timestamped, and accessible.</li>
+        <li>Confirm incident response drills conducted and documented.</li>
+        <li>Provide evidence of model evaluations, bias audits, and privacy impact assessments.</li>
+      </ol>
+      <p>Run internal audits semi-annually to avoid surprises.</p>
+    </section>
+    <section class="page-numbered" id="appendix-af">
+      <h3>Appendix AF: Customer Journey Mapping for Autonomy</h3>
+      <p>Map customer journeys to ensure automation enhances experiences.</p>
+      <ol>
+        <li>Identify key touchpoints (awareness, onboarding, support, renewal).</li>
+        <li>Document customer goals, emotions, and friction points at each stage.</li>
+        <li>Overlay current automations and gaps. Evaluate whether automation adds clarity or confusion.</li>
+        <li>Design future-state journeys with blended human and AI touchpoints.</li>
+        <li>Validate with customers through interviews and usability tests.</li>
+      </ol>
+      <p>Use journey maps to prioritize automation investments that elevate customer outcomes.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ag">
+      <h3>Appendix AG: Measuring Cultural Adoption</h3>
+      <p>Cultural change must be measured.</p>
+      <ul>
+        <li><strong>Sentiment Surveys:</strong> Quarterly pulse surveys on trust, clarity, and empowerment.</li>
+        <li><strong>Participation Rates:</strong> Attendance at autonomy councils, training completion, champion engagement.</li>
+        <li><strong>Idea Pipeline:</strong> Number of automation ideas submitted by employees and implemented.</li>
+        <li><strong>Storytelling Velocity:</strong> Frequency of internal communications celebrating human-machine wins.</li>
+      </ul>
+      <p>Combine metrics into a cultural adoption score shared with leadership.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ah">
+      <h3>Appendix AH: Dashboard Implementation Steps</h3>
+      <p>Implement autonomy dashboards methodically.</p>
+      <ol>
+        <li>Define stakeholder requirements and key questions.</li>
+        <li>Map data sources and ensure schema consistency.</li>
+        <li>Build data models in dbt or similar to standardize metrics.</li>
+        <li>Design visualizations emphasizing trends, exceptions, and guardrails.</li>
+        <li>Integrate alerts and annotations to contextualize anomalies.</li>
+        <li>Conduct usability tests with stakeholders and iterate.</li>
+      </ol>
+      <p>Revisit dashboards quarterly to align with evolving strategy.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ai">
+      <h3>Appendix AI: Multilingual Automation Strategy</h3>
+      <p>Global enterprises must support multiple languages.</p>
+      <ul>
+        <li><strong>Locale Profiles:</strong> Define tone, cultural references, legal requirements per region.</li>
+        <li><strong>Translation Pipelines:</strong> Use AI translation with human review for high-stakes content.</li>
+        <li><strong>Model Localization:</strong> Fine-tune models on local data to capture idioms and preferences.</li>
+        <li><strong>Compliance Alignment:</strong> Ensure privacy notices, consent flows, and customer support comply with local laws.</li>
+        <li><strong>Quality Assurance:</strong> Implement localization QA including linguistic review and functional testing.</li>
+      </ul>
+      <p>Maintain localization playbooks and involve regional teams in governance.</p>
+    </section>
+    <section class="page-numbered" id="appendix-aj">
+      <h3>Appendix AJ: Advanced Agent Patterns</h3>
+      <p>Push agent design further.</p>
+      <ul>
+        <li><strong>Hierarchical Agents:</strong> Supervisory agent breaks goals into subtasks assigned to specialized agents.</li>
+        <li><strong>Market-Based Coordination:</strong> Agents bid on tasks using utility scores, ensuring optimal resource allocation.</li>
+        <li><strong>Memory Sharding:</strong> Separate memory into domain-specific stores (customer insights, technical docs) with retrieval policies.</li>
+        <li><strong>Ethical Overseer:</strong> Dedicated agent evaluates actions against policy, vetoing risky steps.</li>
+      </ul>
+      <p>Experiment with these patterns in sandbox environments before production deployment.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ak">
+      <h3>Appendix AK: Automation Playbook Template</h3>
+      <p>Standardize how teams document automations.</p>
+      <ol>
+        <li><strong>Overview:</strong> Name, owner, business objective.</li>
+        <li><strong>Architecture:</strong> Diagram, data flows, dependencies.</li>
+        <li><strong>Logic:</strong> Prompts, decision rules, fallback paths.</li>
+        <li><strong>Telemetry:</strong> Metrics tracked, alert thresholds, dashboards.</li>
+        <li><strong>Governance:</strong> Human oversight, audit logs, compliance notes.</li>
+        <li><strong>Roadmap:</strong> Planned enhancements, experiments, debt items.</li>
+      </ol>
+      <p>Maintain playbooks in version control and review quarterly.</p>
+    </section>
+    <section class="page-numbered" id="appendix-al">
+      <h3>Appendix AL: ROI Case Calculator</h3>
+      <p>Build calculators to quantify impact. Inputs include manual effort hours, error rates, revenue leakage, and automation costs. Outputs estimate payback period, net present value, and sensitivity analysis. Provide scenario toggles (best, base, worst). Update assumptions as data accrues.</p>
+    </section>
+    <section class="page-numbered" id="appendix-am">
+      <h3>Appendix AM: Talent Development Pathways</h3>
+      <p>Invest in people to sustain autonomy.</p>
+      <ul>
+        <li><strong>Explorer Path:</strong> Intro courses, sandbox experimentation, mentorship.</li>
+        <li><strong>Practitioner Path:</strong> Certification on orchestration platforms, prompt labs, governance projects.</li>
+        <li><strong>Architect Path:</strong> Advanced systems design, risk modeling, leadership coaching.</li>
+        <li><strong>Executive Path:</strong> Strategy workshops, board-level governance, ethical foresight.</li>
+      </ul>
+      <p>Track progress with career frameworks and reward contributions with recognition and promotion opportunities.</p>
+    </section>
+    <section class="page-numbered" id="appendix-an">
+      <h3>Appendix AN: Automation Retrospective Template</h3>
+      <p>Run retrospectives to harvest lessons.</p>
+      <ol>
+        <li>What was the objective and did we achieve it?</li>
+        <li>What went well? Highlight technical wins and human stories.</li>
+        <li>What surprised us? Capture unexpected behaviors, data insights, stakeholder reactions.</li>
+        <li>What slowed us down? Note blockers, dependencies, or governance friction.</li>
+        <li>What will we do next? Assign owners, deadlines, and follow-up experiments.</li>
+      </ol>
+      <p>Share retrospective summaries across teams to accelerate collective learning.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ao">
+      <h3>Appendix AO: Open Source Tooling Landscape</h3>
+      <p>Explore open source options to avoid vendor lock-in.</p>
+      <ul>
+        <li><strong>Orchestration:</strong> n8n, Temporal OSS, Airflow.</li>
+        <li><strong>Vector Databases:</strong> Weaviate, Qdrant, Milvus.</li>
+        <li><strong>Monitoring:</strong> Prometheus, Grafana, OpenTelemetry collectors.</li>
+        <li><strong>Agent Frameworks:</strong> LangChain, LlamaIndex, Haystack.</li>
+        <li><strong>Policy Engines:</strong> Open Policy Agent, Cedar.</li>
+      </ul>
+      <p>Assess community activity, documentation, and security practices before adoption.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ap">
+      <h3>Appendix AP: Financial Modeling for Autonomy</h3>
+      <p>Integrate autonomy into financial planning.</p>
+      <ul>
+        <li><strong>Cost Baseline:</strong> Labor, infrastructure, software, training.</li>
+        <li><strong>Value Drivers:</strong> Revenue growth, churn reduction, efficiency gains, risk mitigation.</li>
+        <li><strong>Sensitivity Analysis:</strong> Model best/worst cases for adoption, performance, and cost volatility.</li>
+        <li><strong>Capital Allocation:</strong> Determine reinvestment of savings into innovation or reserves.</li>
+        <li><strong>Reporting Cadence:</strong> Include autonomy metrics in monthly financial reviews and investor updates.</li>
+      </ul>
+      <p>Align finance and automation teams to maintain credibility.</p>
+    </section>
+    <section class="page-numbered" id="appendix-aq">
+      <h3>Appendix AQ: Governance Board Charter</h3>
+      <p>Create a charter for autonomy governance boards.</p>
+      <ul>
+        <li><strong>Mission:</strong> Ensure autonomy aligns with strategy, ethics, and compliance.</li>
+        <li><strong>Composition:</strong> Include executives, architects, legal, security, operations, and customer advocates.</li>
+        <li><strong>Responsibilities:</strong> Approve major automations, review incidents, monitor metrics, guide policy updates.</li>
+        <li><strong>Cadence:</strong> Monthly meetings with quarterly deep dives.</li>
+        <li><strong>Decision Rights:</strong> Define which decisions require board approval versus delegated authority.</li>
+      </ul>
+      <p>Publish minutes to maintain transparency.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ar">
+      <h3>Appendix AR: Communication Plan Template</h3>
+      <p>Communicate autonomy progress effectively.</p>
+      <ol>
+        <li>Audience segmentation: executives, managers, frontline teams, customers.</li>
+        <li>Message pillars: vision, safeguards, wins, opportunities to participate.</li>
+        <li>Channels: town halls, newsletters, intranet, customer updates.</li>
+        <li>Frequency: monthly updates, real-time alerts for major launches.</li>
+        <li>Feedback loops: Q&amp;A sessions, surveys, dedicated Slack channels.</li>
+      </ol>
+      <p>Consistent communication builds trust and alignment.</p>
+    </section>
+    <section class="page-numbered" id="appendix-as">
+      <h3>Appendix AS: Innovation Funnel Management</h3>
+      <p>Manage automation ideas like a product pipeline.</p>
+      <ol>
+        <li><strong>Ideation:</strong> Collect ideas via portals, hackathons, and retros.</li>
+        <li><strong>Qualification:</strong> Evaluate impact, feasibility, and alignment using standardized scorecards.</li>
+        <li><strong>Incubation:</strong> Build prototypes, run experiments, gather user feedback.</li>
+        <li><strong>Acceleration:</strong> Secure funding, assign squads, integrate governance.</li>
+        <li><strong>Scale:</strong> Deploy broadly, measure outcomes, and feed lessons back into ideation.</li>
+      </ol>
+      <p>Maintain visibility of the funnel to prevent innovation bottlenecks.</p>
+    </section>
+    <section class="page-numbered" id="appendix-at">
+      <h3>Appendix AT: Platform Migration Checklist</h3>
+      <p>When switching platforms, follow this checklist:</p>
+      <ol>
+        <li>Inventory current automations, dependencies, and data flows.</li>
+        <li>Map equivalent capabilities in target platform.</li>
+        <li>Plan phased migration with fallbacks and dual-running where possible.</li>
+        <li>Test data integrity, performance, and security in staging environments.</li>
+        <li>Communicate changes to stakeholders and provide training.</li>
+        <li>Retire old systems with audit of residual data and access.</li>
+      </ol>
+      <p>Migrations are strategic; allocate time for validation and change management.</p>
+    </section>
+    <section class="page-numbered" id="appendix-au">
+      <h3>Appendix AU: Automation SLA Framework</h3>
+      <p>Define service-level agreements for automations.</p>
+      <ul>
+        <li><strong>Availability:</strong> Target uptime and redundancy expectations.</li>
+        <li><strong>Latency:</strong> Response time thresholds for different workflows.</li>
+        <li><strong>Accuracy:</strong> Acceptable error rates or override thresholds.</li>
+        <li><strong>Support:</strong> Response times for incidents, ownership matrix.</li>
+        <li><strong>Review Cadence:</strong> Schedule for SLA evaluation and updates.</li>
+      </ul>
+      <p>SLAs set expectations and align teams on reliability goals.</p>
+    </section>
+    <section class="page-numbered" id="appendix-av">
+      <h3>Appendix AV: Benchmark Dataset Catalog</h3>
+      <p>Curate benchmark datasets for evaluation and training.</p>
+      <ul>
+        <li><strong>Internal:</strong> Historical tickets, marketing campaigns, operational logs.</li>
+        <li><strong>External:</strong> Open datasets relevant to your industry (e.g., financial time series, product reviews).</li>
+        <li><strong>Synthetic:</strong> Generated scenarios for stress testing edge cases.</li>
+        <li><strong>Annotation:</strong> Process for labeling, quality control, and versioning.</li>
+      </ul>
+      <p>Maintain a catalog with metadata, access controls, and usage guidelines.</p>
+    </section>
+    <section class="page-numbered" id="appendix-aw">
+      <h3>Appendix AW: Ethics Workshop Agenda</h3>
+      <p>Host ethics workshops with structure.</p>
+      <ol>
+        <li>Introduction: articulate why ethics matters, share recent news.</li>
+        <li>Scenario analysis: teams assess hypothetical dilemmas, identify risks and mitigations.</li>
+        <li>Model transparency demo: show how explainability tools reveal decision logic.</li>
+        <li>Policy review: revisit ethics policies, gather feedback for updates.</li>
+        <li>Action planning: assign owners to follow-up actions and training needs.</li>
+      </ol>
+      <p>Workshops reinforce responsible autonomy culture.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ax">
+      <h3>Appendix AX: Risk Communication Plan</h3>
+      <p>Communicate risks clearly to stakeholders.</p>
+      <ul>
+        <li><strong>Risk Register Digest:</strong> Monthly summary of top risks, status, and mitigation progress.</li>
+        <li><strong>Incident Briefings:</strong> Rapid communication templates for incidents detailing impact, response, and lessons.</li>
+        <li><strong>Board Updates:</strong> Quarterly risk narrative linked to metrics and mitigation roadmaps.</li>
+        <li><strong>Employee Messaging:</strong> Transparent updates that build trust and encourage reporting.</li>
+      </ul>
+      <p>Clear communication prevents panic and aligns action.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ay">
+      <h3>Appendix AY: Success Stories Library</h3>
+      <p>Capture stories to inspire adoption.</p>
+      <ol>
+        <li>Story template: problem, solution, outcome, human perspective.</li>
+        <li>Media formats: written case studies, videos, podcasts.</li>
+        <li>Distribution: internal newsletters, town halls, customer marketing.</li>
+        <li>Measurement: track story engagement and impact on adoption metrics.</li>
+      </ol>
+      <p>Stories translate metrics into meaning.</p>
+    </section>
+    <section class="page-numbered" id="appendix-az">
+      <h3>Appendix AZ: Capability Matrix</h3>
+      <p>Map capabilities against maturity to identify gaps.</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th>Current Maturity (1-5)</th>
+            <th>Target Maturity</th>
+            <th>Owner</th>
+            <th>Next Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Event Ingestion</td>
+            <td>3</td>
+            <td>5</td>
+            <td>Platform Engineering</td>
+            <td>Implement schema registry, expand to new domains</td>
+          </tr>
+          <tr>
+            <td>Model Evaluation</td>
+            <td>2</td>
+            <td>4</td>
+            <td>Data Science</td>
+            <td>Deploy automated evaluation pipelines</td>
+          </tr>
+          <tr>
+            <td>Ethics Governance</td>
+            <td>2</td>
+            <td>5</td>
+            <td>Governance Lead</td>
+            <td>Establish ethics council, create policy-as-code</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Review matrix during strategy sessions to align investments.</p>
+    </section>
+    <section class="page-numbered" id="appendix-ba">
+      <h3>Appendix BA: Stakeholder Map</h3>
+      <p>Identify stakeholders and their interests.</p>
+      <ul>
+        <li><strong>Executives:</strong> Focus on strategic alignment, ROI, risk.</li>
+        <li><strong>Operations:</strong> Value reliability, clarity, reduced toil.</li>
+        <li><strong>Engineering:</strong> Need maintainability, observability, technical autonomy.</li>
+        <li><strong>Legal &amp; Compliance:</strong> Demand auditability, policy adherence.</li>
+        <li><strong>Customers:</strong> Expect transparency, responsiveness, value.</li>
+      </ul>
+      <p>Use stakeholder maps to tailor communication and involvement.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bb">
+      <h3>Appendix BB: Principle Manifesto</h3>
+      <p>Codify guiding principles to align teams:</p>
+      <ol>
+        <li><strong>Design for Trust:</strong> Transparency and explainability are non-negotiable.</li>
+        <li><strong>Elevate Humans:</strong> Automation amplifies human creativity and judgment.</li>
+        <li><strong>Learn Relentlessly:</strong> Every output is feedback; every incident is an opportunity.</li>
+        <li><strong>Govern Proactively:</strong> Ethics, compliance, and security are built-in.</li>
+        <li><strong>Scale Responsibly:</strong> Growth must be resilient, inclusive, and sustainable.</li>
+      </ol>
+      <p>Display the manifesto in onboarding materials and strategy sessions.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bc">
+      <h3>Appendix BC: Automation Audit Report Template</h3>
+      <p>Document audits comprehensively.</p>
+      <ol>
+        <li>Executive summary with scope, findings, and recommendations.</li>
+        <li>Methodology detailing data sources, interviews, and tests performed.</li>
+        <li>Findings categorized by severity with evidence and impact.</li>
+        <li>Remediation plan with owners, timelines, and success metrics.</li>
+        <li>Follow-up schedule to verify remediation.</li>
+      </ol>
+      <p>Standardized reports accelerate governance decisions.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bd">
+      <h3>Appendix BD: Crisis Simulation Playbook</h3>
+      <p>Simulate crises to strengthen resilience.</p>
+      <ol>
+        <li>Select scenarios (model hallucination, data breach, platform outage).</li>
+        <li>Define success criteria: detection time, response coordination, communication clarity.</li>
+        <li>Run tabletop exercises with cross-functional teams.</li>
+        <li>Debrief to capture lessons, update runbooks, and adjust guardrails.</li>
+      </ol>
+      <p>Regular simulations reduce panic during real incidents.</p>
+    </section>
+    <section class="page-numbered" id="appendix-be">
+      <h3>Appendix BE: Research &amp; Development Agenda</h3>
+      <p>Plan long-term innovation.</p>
+      <ul>
+        <li><strong>Emerging Models:</strong> Evaluate new AI models, multimodal capabilities, and domain-specific fine-tunes.</li>
+        <li><strong>Edge Autonomy:</strong> Explore edge computing for latency-sensitive automations.</li>
+        <li><strong>Neuro-symbolic Approaches:</strong> Combine symbolic reasoning with LLMs for higher reliability.</li>
+        <li><strong>Sustainability:</strong> Measure energy usage and pursue green compute options.</li>
+      </ul>
+      <p>Update agenda annually and align with corporate R&amp;D initiatives.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bf">
+      <h3>Appendix BF: Automation Health Score</h3>
+      <p>Construct a composite health score.</p>
+      <ul>
+        <li><strong>Performance:</strong> Weighted average of uptime, latency, and accuracy.</li>
+        <li><strong>Adoption:</strong> Percentage of target workflows utilizing automation.</li>
+        <li><strong>Trust:</strong> Survey-based trust index normalized 0-100.</li>
+        <li><strong>Governance:</strong> Compliance score factoring policy adherence and audit readiness.</li>
+        <li><strong>Innovation:</strong> Experiment velocity and learning cycle time.</li>
+      </ul>
+      <p>Scale the score 0-100 and categorize (critical, watch, healthy). Use to prioritize attention.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bg">
+      <h3>Appendix BG: Partner Ecosystem Strategy</h3>
+      <p>Develop partner strategies to extend capabilities.</p>
+      <ul>
+        <li>Identify partners for data enrichment, specialized AI models, implementation services.</li>
+        <li>Define partner tiers (strategic, solution, technology) with expectations.</li>
+        <li>Establish co-selling and co-marketing motions.</li>
+        <li>Create partner enablement kits with architecture diagrams, playbooks, and governance guidelines.</li>
+        <li>Measure partner impact on adoption, revenue, and customer satisfaction.</li>
+      </ul>
+      <p>Partnerships accelerate innovation and market reach.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bh">
+      <h3>Appendix BH: Continuous Learning Roadmap</h3>
+      <p>Keep teams at the frontier.</p>
+      <ol>
+        <li>Subscribe to research updates, standards bodies, and community forums.</li>
+        <li>Host quarterly innovation days to test emerging tools.</li>
+        <li>Reward employees who publish learnings or contribute to open source.</li>
+        <li>Benchmark against peers via industry consortiums.</li>
+      </ol>
+      <p>Continuous learning ensures your enterprise remains a pioneer.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bi">
+      <h3>Appendix BI: Risk Registry Template</h3>
+      <p>Maintain a living risk register.</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Category</th>
+            <th>Likelihood</th>
+            <th>Impact</th>
+            <th>Owner</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Model drift causing inaccurate decisions</td>
+            <td>Data</td>
+            <td>Medium</td>
+            <td>High</td>
+            <td>Head of Data Science</td>
+            <td>Implement monitoring and scheduled retraining</td>
+          </tr>
+          <tr>
+            <td>API rate limit breach</td>
+            <td>Technical</td>
+            <td>High</td>
+            <td>Medium</td>
+            <td>Automation Ops</td>
+            <td>Deploy backoff logic and caching</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Review monthly and update after incidents.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bj">
+      <h3>Appendix BJ: Annual Planning Checklist</h3>
+      <p>Plan the autonomy roadmap annually.</p>
+      <ol>
+        <li>Review previous year's outcomes, incidents, and lessons.</li>
+        <li>Update capability heatmaps and maturity assessments.</li>
+        <li>Set strategic themes (e.g., customer intelligence, resilient ops, agent innovation).</li>
+        <li>Prioritize initiatives with scoring models (impact, cost, risk).</li>
+        <li>Align budgets, staffing, and governance structures.</li>
+        <li>Communicate plan across organization with clear milestones.</li>
+      </ol>
+      <p>Annual planning ensures coherence and momentum.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bk">
+      <h3>Appendix BK: Multi-Tenant Strategy</h3>
+      <p>For platforms serving multiple business units or customers, design multi-tenancy carefully.</p>
+      <ul>
+        <li>Segregate data with tenant IDs and enforce row-level security.</li>
+        <li>Offer configuration layers that allow customization without code forks.</li>
+        <li>Implement usage metering per tenant to inform billing and capacity planning.</li>
+        <li>Provide tenant-specific dashboards and governance controls.</li>
+        <li>Establish tenant onboarding playbooks with security and compliance reviews.</li>
+      </ul>
+      <p>Balanced multi-tenancy unlocks economies of scale while preserving trust.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bl">
+      <h3>Appendix BL: Sustainability Practices</h3>
+      <p>Align autonomy with environmental stewardship.</p>
+      <ul>
+        <li>Track compute usage and carbon footprint of AI workloads.</li>
+        <li>Prioritize energy-efficient infrastructure and regions powered by renewables.</li>
+        <li>Optimize prompts and inference to reduce unnecessary calls.</li>
+        <li>Offset emissions through certified programs and transparent reporting.</li>
+        <li>Design automations that reduce waste in supply chains and operations.</li>
+      </ul>
+      <p>Sustainable autonomy builds reputational and operational resilience.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bm">
+      <h3>Appendix BM: Data Residency Strategy</h3>
+      <p>Plan for data residency compliance.</p>
+      <ul>
+        <li>Map jurisdictions and applicable regulations.</li>
+        <li>Deploy regional data stores with encryption and access controls.</li>
+        <li>Implement routing logic to ensure data stays within approved regions.</li>
+        <li>Monitor cross-border data flows and maintain audit logs.</li>
+        <li>Coordinate with legal teams for contractual clauses and disclosures.</li>
+      </ul>
+    </section>
+    <section class="page-numbered" id="appendix-bn">
+      <h3>Appendix BN: Autonomy KPI Scorecard Example</h3>
+      <p>Example monthly scorecard:</p>
+      <table class="table-grid">
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>Target</th>
+            <th>Current</th>
+            <th>Trend</th>
+            <th>Owner</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Autonomy Confidence</td>
+            <td>85%</td>
+            <td>82%</td>
+            <td>⬆︎</td>
+            <td>Automation Architect</td>
+          </tr>
+          <tr>
+            <td>Override Rate</td>
+            <td>&lt;5%</td>
+            <td>4.2%</td>
+            <td>⬇︎</td>
+            <td>Operations Lead</td>
+          </tr>
+          <tr>
+            <td>Experiment Velocity</td>
+            <td>12/mo</td>
+            <td>10/mo</td>
+            <td>⬆︎</td>
+            <td>Growth Team</td>
+          </tr>
+          <tr>
+            <td>Ethics Compliance</td>
+            <td>100%</td>
+            <td>98%</td>
+            <td>⬇︎</td>
+            <td>Governance Lead</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Scorecards focus action and accountability.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bo">
+      <h3>Appendix BO: Vision Narrative Template</h3>
+      <p>Create a vivid narrative to align teams on the future state. Describe a day in the life of your enterprise five years ahead. Highlight how customers interact with adaptive systems, how employees collaborate with agents, how decisions flow through transparent dashboards, and how governance maintains trust. Include sensory detail—alerts lighting up like auroras, voice agents conversing in multiple languages, executives reviewing real-time autonomy confidence scores before strategy sessions. Narratives inspire action by making the future tangible.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bp">
+      <h3>Appendix BP: Leadership Manifesto</h3>
+      <p>Leaders must model the future they seek. Commit to learning alongside your teams, to making data-backed decisions, to celebrating curiosity, and to confronting risks transparently. Promise to measure success not only in efficiency but in resilience, customer delight, and employee growth. Pledge to keep humans at the center while embracing the acceleration that autonomy provides. Share this manifesto with your leadership circle and revisit it whenever strategic drift threatens clarity.</p>
+    </section>
+    <section class="page-numbered" id="appendix-bq">
+      <h3>Appendix BQ: Continuous Feedback Loop Reminder</h3>
+      <p>Never let feedback stagnate. Automate surveys, host open office hours, and rotate team members through shadowing sessions so that lived experience continually shapes the architecture.</p>
+    </section>
+    </section>
+    </section>
+  </section>
+
+<footer class="page-numbered">
+  <h3>Your Enterprise is Now a Living Organism</h3>
+  <p>You are no longer just a business owner or a developer. You are an architect of complex, adaptive systems. The blueprints in this guide are your starting point, not your limit. The tools will evolve, the models will become more powerful, but the principles of strategic design will remain. The future is not just automated; it is autonomous. Go build it.</p>
+  <p><strong>This knowledge is power. True mastery comes from community and continuous learning. Join my private community, "The Architect's Forge", to discuss these systems, share your creations, and get access to exclusive workshops and live Q&amp;As. The link is your initiation.</strong></p>
+  <p>To the bleeding edge,<br />dim_flows</p>
+  <p>&copy; 2025 dim_flows | Architecting the Future</p>
+</footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a neon-dark themed, single-page HTML ebook with custom typography, responsive layout, and styled interactive elements
- author extensive content covering strategic mindset, tooling, real-world playbooks, future ethics, and a deep appendix catalog for automation architects
- integrate persistent neon page-number markers across the table of contents, chapters, appendices, and footer to emulate ebook pagination

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6593b6bec8327927da7b427ef34f2